### PR TITLE
explicitly include required frameworks in image pixel buffer extensions

### DIFF
--- a/TensorIO/Classes/TIO Utilities/UIImage+TIOCVPixelBufferExtensions.h
+++ b/TensorIO/Classes/TIO Utilities/UIImage+TIOCVPixelBufferExtensions.h
@@ -21,6 +21,8 @@
 #import <UIKit/UIKit.h>
 #import <AVFoundation/AVFoundation.h>
 #import <VideoToolbox/VideoToolbox.h>
+#import <CoreGraphics/CoreGraphics.h>
+#import <CoreVideo/CoreVideo.h>
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
Came up when I was using this file on its own in another project.