### PR TITLE
Batch data source and model trainer

### DIFF
--- a/Example/TensorIO.xcodeproj/project.pbxproj
+++ b/Example/TensorIO.xcodeproj/project.pbxproj
@@ -36,6 +36,10 @@
 		E34F12D32278CA4F000A0DD7 /* TIOModelModesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E34F12D22278CA4F000A0DD7 /* TIOModelModesTests.m */; };
 		E3B1AD0E214ADE7E0094E065 /* TensorIOModelBundleValidatorTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E3B1AD0D214ADE7E0094E065 /* TensorIOModelBundleValidatorTests.mm */; };
 		E3B2A902227226C20080DFDD /* TIOBatchTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E3B2A901227226C20080DFDD /* TIOBatchTests.m */; };
+		E3E16DD0229321D00087197A /* TIOMockTrainableModel.m in Sources */ = {isa = PBXBuildFile; fileRef = E3E16DCE229321D00087197A /* TIOMockTrainableModel.m */; };
+		E3E16DD2229321D90087197A /* TIOModelTrainerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E3E16DD1229321D90087197A /* TIOModelTrainerTests.m */; };
+		E3E16DD7229322640087197A /* TIOMockBatchDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = E3E16DD6229322640087197A /* TIOMockBatchDataSource.m */; };
+		E3E16DD92293231D0087197A /* TIOInMemoryBatchDataSourceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E3E16DD82293231D0087197A /* TIOInMemoryBatchDataSourceTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -93,6 +97,12 @@
 		E34F12D22278CA4F000A0DD7 /* TIOModelModesTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TIOModelModesTests.m; sourceTree = "<group>"; };
 		E3B1AD0D214ADE7E0094E065 /* TensorIOModelBundleValidatorTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TensorIOModelBundleValidatorTests.mm; sourceTree = "<group>"; };
 		E3B2A901227226C20080DFDD /* TIOBatchTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TIOBatchTests.m; sourceTree = "<group>"; };
+		E3E16DCE229321D00087197A /* TIOMockTrainableModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TIOMockTrainableModel.m; sourceTree = "<group>"; };
+		E3E16DCF229321D00087197A /* TIOMockTrainableModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TIOMockTrainableModel.h; sourceTree = "<group>"; };
+		E3E16DD1229321D90087197A /* TIOModelTrainerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TIOModelTrainerTests.m; sourceTree = "<group>"; };
+		E3E16DD5229322640087197A /* TIOMockBatchDataSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TIOMockBatchDataSource.h; sourceTree = "<group>"; };
+		E3E16DD6229322640087197A /* TIOMockBatchDataSource.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TIOMockBatchDataSource.m; sourceTree = "<group>"; };
+		E3E16DD82293231D0087197A /* TIOInMemoryBatchDataSourceTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TIOInMemoryBatchDataSourceTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -191,6 +201,11 @@
 		6003F5B5195388D20070C39A /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				6003F5B6195388D20070C39A /* Supporting Files */,
+				E3E16DCF229321D00087197A /* TIOMockTrainableModel.h */,
+				E3E16DCE229321D00087197A /* TIOMockTrainableModel.m */,
+				E3E16DD5229322640087197A /* TIOMockBatchDataSource.h */,
+				E3E16DD6229322640087197A /* TIOMockBatchDataSource.m */,
 				E31C7995212DF38300139C90 /* TensorIOJSONParsingTests.mm */,
 				E31C79DE212F63AC00139C90 /* TensorIODataTests.mm */,
 				E31C7999212E06CF00139C90 /* TensorIOTFLiteModelIntegrationTests.mm */,
@@ -200,7 +215,8 @@
 				E3197F732268F19B0082047D /* TIOModelBackendTests.mm */,
 				E34F12D22278CA4F000A0DD7 /* TIOModelModesTests.m */,
 				E3B2A901227226C20080DFDD /* TIOBatchTests.m */,
-				6003F5B6195388D20070C39A /* Supporting Files */,
+				E3E16DD1229321D90087197A /* TIOModelTrainerTests.m */,
+				E3E16DD82293231D0087197A /* TIOInMemoryBatchDataSourceTests.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -442,13 +458,17 @@
 			files = (
 				E30DF2D3214862A0008DBCB7 /* TensorIOModelBundleManagerTests.mm in Sources */,
 				E31C7996212DF38300139C90 /* TensorIOJSONParsingTests.mm in Sources */,
+				E3E16DD92293231D0087197A /* TIOInMemoryBatchDataSourceTests.m in Sources */,
 				E34F12D32278CA4F000A0DD7 /* TIOModelModesTests.m in Sources */,
 				E3197F6E2267C7640082047D /* TensorIOLayerInterfaceTests.mm in Sources */,
 				E3B2A902227226C20080DFDD /* TIOBatchTests.m in Sources */,
 				E3B1AD0E214ADE7E0094E065 /* TensorIOModelBundleValidatorTests.mm in Sources */,
 				E31C79DF212F63AC00139C90 /* TensorIODataTests.mm in Sources */,
 				E3197F752268F57F0082047D /* TIOModelBackendTests.mm in Sources */,
+				E3E16DD2229321D90087197A /* TIOModelTrainerTests.m in Sources */,
 				E31C799A212E06CF00139C90 /* TensorIOTFLiteModelIntegrationTests.mm in Sources */,
+				E3E16DD7229322640087197A /* TIOMockBatchDataSource.m in Sources */,
+				E3E16DD0229321D00087197A /* TIOMockTrainableModel.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/Tests/TIOBatchTests.m
+++ b/Example/Tests/TIOBatchTests.m
@@ -48,7 +48,12 @@
         @"label": @[@1]
     }];
     
-    XCTAssert(batch.count == 2);
+    [batch addItem:@{
+        @"image": @[@7,@8,@9],
+        @"label": @[@1]
+    }];
+    
+    XCTAssert(batch.count == 3);
     
     XCTAssertEqualObjects([batch itemAtIndex:0], (@{
         @"image": @[@1,@2,@3],
@@ -60,13 +65,20 @@
         @"label": @[@1]
     }));
     
+    XCTAssertEqualObjects([batch itemAtIndex:2], (@{
+        @"image": @[@7,@8,@9],
+        @"label": @[@1]
+    }));
+    
     XCTAssertEqualObjects([batch valuesForKey:@"image"], (@[
         @[@1,@2,@3],
-        @[@4,@5,@6]
+        @[@4,@5,@6],
+        @[@7,@8,@9]
     ]));
     
     XCTAssertEqualObjects([batch valuesForKey:@"label"], (@[
         @[@0],
+        @[@1],
         @[@1]
     ]));
 }

--- a/Example/Tests/TIOInMemoryBatchDataSourceTests.m
+++ b/Example/Tests/TIOInMemoryBatchDataSourceTests.m
@@ -1,0 +1,103 @@
+//
+//  TIOInMemoryBatchDataSourceTests.m
+//  TensorIO_Tests
+//
+//  Created by Phil Dow on 5/20/19.
+//  Copyright © 2019 doc.ai (http://doc.ai)
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <XCTest/XCTest.h>
+#import <TensorIO/TensorIO-umbrella.h>
+
+@interface TIOInMemoryBatchDataSourceTests : XCTestCase
+
+@property TIOBatchItem *item;
+@property TIOBatch *batch;
+
+@end
+
+@implementation TIOInMemoryBatchDataSourceTests
+
+- (void)setUp {
+    
+    // Single item tests
+    
+    self.item = @{
+        @"image": @[@(0),@(1),@(2)],
+        @"label": @(-1)
+    };
+    
+    // Batch tests
+    
+    self.batch = [[TIOBatch alloc] initWithKeys:@[
+        @"image",
+        @"label"
+    ]];
+    
+    [self.batch addItem:@{
+        @"image": @[@(0),@(1),@(2)],
+        @"label": @(-1)
+    }];
+    
+    [self.batch addItem:@{
+        @"image": @[@(3),@(4),@(5)],
+        @"label": @(0)
+    }];
+    
+    [self.batch addItem:@{
+        @"image": @[@(6),@(7),@(8)],
+        @"label": @(1)
+    }];
+}
+
+- (void)tearDown { }
+
+- (void)testInitsWithBatchCorrectly {
+    TIOInMemoryBatchDataSource *source = [[TIOInMemoryBatchDataSource alloc] initWithItem:self.item];
+    
+    XCTAssert(source.numberOfItems == 1);
+    XCTAssertEqualObjects([source.batch itemAtIndex:0], self.item);
+}
+
+- (void)testInitsWithBatchItemCorrectly {
+    TIOInMemoryBatchDataSource *source = [[TIOInMemoryBatchDataSource alloc] initWithBatch:self.batch];
+    
+    XCTAssert(source.numberOfItems == 3);
+    XCTAssertEqualObjects([source.batch itemAtIndex:0], [self.batch itemAtIndex:0]);
+    XCTAssertEqualObjects([source.batch itemAtIndex:1], [self.batch itemAtIndex:1]);
+    XCTAssertEqualObjects([source.batch itemAtIndex:2], [self.batch itemAtIndex:2]);
+}
+
+- (void)testReturnsCorrectKeys {
+    TIOInMemoryBatchDataSource *source = [[TIOInMemoryBatchDataSource alloc] initWithBatch:self.batch];
+    
+    XCTAssertEqualObjects(source.keys, (@[@"image", @"label"]));
+}
+
+- (void)testReturnsCorrectNumberOfItems {
+    TIOInMemoryBatchDataSource *source = [[TIOInMemoryBatchDataSource alloc] initWithBatch:self.batch];
+    
+    XCTAssert(source.numberOfItems == 3);
+}
+
+- (void)testReturnsCorrectItemAtIndex {
+    TIOInMemoryBatchDataSource *source = [[TIOInMemoryBatchDataSource alloc] initWithBatch:self.batch];
+    
+    XCTAssertEqualObjects([source itemAtIndex:0], [self.batch itemAtIndex:0]);
+    XCTAssertEqualObjects([source itemAtIndex:1], [self.batch itemAtIndex:1]);
+    XCTAssertEqualObjects([source itemAtIndex:2], [self.batch itemAtIndex:2]);
+}
+
+@end

--- a/Example/Tests/TIOMockBatchDataSource.h
+++ b/Example/Tests/TIOMockBatchDataSource.h
@@ -1,0 +1,53 @@
+//
+//  TIOMockBatchDataSource.h
+//  TensorIO_Tests
+//
+//  Created by Phil Dow on 5/20/19.
+//  Copyright © 2019 doc.ai (http://doc.ai)
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+#import <TensorIO/TensorIO-umbrella.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * The mock batch data source tracks the number of times `itemAtIndex:` is
+ * called for each index and is used to validate `TIOModelTrainer` behavior.
+ */
+
+@interface TIOMockBatchDataSource : NSObject <TIOBatchDataSource>
+
+// MARK: - Mock Properties
+
+/**
+ * Tracks number of times itemAtIndex has been called for a particular index.
+ */
+
+@property (readonly) NSArray<NSNumber*> *itemAtIndexCount;
+- (NSUInteger)itemAtIndexCountAtIndex:(NSUInteger)index;
+
+- (instancetype)initWithItemCount:(NSUInteger)count;
+
+// MARK: - TIOBatchDataSource
+
+@property (readonly) NSArray<NSString*> *keys;
+
+- (NSUInteger)numberOfItems;
+- (TIOBatchItem*)itemAtIndex:(NSUInteger)index;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Example/Tests/TIOMockBatchDataSource.m
+++ b/Example/Tests/TIOMockBatchDataSource.m
@@ -1,8 +1,8 @@
 //
-//  TIOInMemoryBatchDataSource.m
-//  TensorIO
+//  TIOMockBatchDataSource.m
+//  TensorIO_Tests
 //
-//  Created by Phil Dow on 5/19/19.
+//  Created by Phil Dow on 5/20/19.
 //  Copyright © 2019 doc.ai (http://doc.ai)
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,31 +18,44 @@
 //  limitations under the License.
 //
 
-#import "TIOInMemoryBatchDataSource.h"
+#import "TIOMockBatchDataSource.h"
 
-@implementation TIOInMemoryBatchDataSource
+@implementation TIOMockBatchDataSource {
+    NSUInteger _itemCount;
+}
 
-- (instancetype)initWithBatch:(TIOBatch*)batch {
+- (instancetype)initWithItemCount:(NSUInteger)count {
     if ((self=[super init])) {
-        _batch = batch;
+        _itemAtIndexCount = [[NSMutableArray alloc] init];
+        _itemCount = count;
+        
+        for (NSUInteger i = 0; i < _itemCount; i++) {
+            ((NSMutableArray*)_itemAtIndexCount)[i] = @(0);
+        }
     }
     return self;
 }
 
-- (instancetype)initWithItem:(TIOBatchItem*)item {
-    return [self initWithBatch:[[TIOBatch alloc] initWithItem:item]];
+- (NSUInteger)itemAtIndexCountAtIndex:(NSUInteger)index {
+    return _itemAtIndexCount[index].unsignedIntegerValue;
 }
 
+// MARK: - TIOBatchDataSource
+
 - (NSArray<NSString*>*)keys {
-    return self.batch.keys;
+    return @[@"foo"];
 }
 
 - (NSUInteger)numberOfItems {
-    return self.batch.count;
+    return _itemCount;
 }
 
 - (TIOBatchItem*)itemAtIndex:(NSUInteger)index {
-    return [self.batch itemAtIndex:index];
+    ((NSMutableArray*)_itemAtIndexCount)[index] = @(_itemAtIndexCount[index].unsignedIntegerValue+1);
+    
+    return @{
+        @"foo": @[@(1)]
+    };
 }
 
 @end

--- a/Example/Tests/TIOMockTrainableModel.h
+++ b/Example/Tests/TIOMockTrainableModel.h
@@ -1,0 +1,95 @@
+//
+//  TIOMockTrainableModel.h
+//  TensorIO_Example
+//
+//  Created by Phil Dow on 5/20/19.
+//  Copyright © 2019 doc.ai (http://doc.ai)
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+#import <TensorIO/TensorIO-umbrella.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * The mock trainable model tracks the number of times `run:` and `train:` have
+ * been called and is used to validate `TIOModelTrainer` behavior.
+ */
+
+@interface TIOMockTrainableModel : NSObject <TIOModel, TIOTrainableModel>
+
+// MARK: - Mock Properties
+
+/**
+ * Tracks number of times the run: method has been called.
+ */
+
+@property (readonly) NSUInteger runCount;
+
+/**
+ * Tracks number of times the train: method has been called.
+ */
+
+@property (readonly) NSUInteger trainCount;
+
+- (instancetype)initMock;
+
+// MARK: - TIOModel
+
++ (nullable instancetype)modelWithBundleAtPath:(NSString*)path;
+
+// Model Protocol Properties
+
+@property (readonly) TIOModelBundle *bundle;
+@property (readonly) TIOModelOptions *options;
+@property (readonly) NSString* identifier;
+@property (readonly) NSString* name;
+@property (readonly) NSString* details;
+@property (readonly) NSString* author;
+@property (readonly) NSString* license;
+@property (readonly) BOOL placeholder;
+@property (readonly) BOOL quantized;
+@property (readonly) NSString *type;
+@property (readonly) NSString *backend;
+@property (readonly) TIOModelModes *modes;
+@property (readonly) BOOL loaded;
+
+@property (readonly) NSArray<TIOLayerInterface*> *inputs;
+@property (readonly) NSArray<TIOLayerInterface*> *outputs;
+
+- (nullable instancetype)initWithBundle:(TIOModelBundle*)bundle NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+- (BOOL)load:(NSError**)error;
+- (void)unload;
+
+- (id<TIOData>)runOn:(id<TIOData>)input;
+
+- (id<TIOLayerDescription>)descriptionOfInputAtIndex:(NSUInteger)index;
+- (id<TIOLayerDescription>)descriptionOfInputWithName:(NSString*)name;
+
+- (id<TIOLayerDescription>)descriptionOfOutputAtIndex:(NSUInteger)index;
+- (id<TIOLayerDescription>)descriptionOfOutputWithName:(NSString*)name;
+
+// MARK: - TIOTrainableModel
+
+- (id<TIOData>)train:(TIOBatch*)batch;
+
+- (BOOL)exportTo:(NSURL*)fileURL error:(NSError**)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Example/Tests/TIOMockTrainableModel.m
+++ b/Example/Tests/TIOMockTrainableModel.m
@@ -1,0 +1,92 @@
+//
+//  TIOMockTrainableModel.m
+//  TensorIO_Example
+//
+//  Created by Phil Dow on 5/20/19.
+//  Copyright © 2019 doc.ai (http://doc.ai)
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "TIOMockTrainableModel.h"
+
+@implementation TIOMockTrainableModel
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wobjc-designated-initializers"
+
+- (instancetype)initMock {
+    if ((self=[super init])) {
+    
+    }
+    return self;
+}
+
+#pragma GCC diagnostic pop
+
++ (nullable instancetype)modelWithBundleAtPath:(NSString*)path {
+    return [[TIOMockTrainableModel alloc] initWithBundle:[[TIOModelBundle alloc] initWithPath:path]];
+}
+
+- (nullable instancetype)initWithBundle:(TIOModelBundle*)bundle {
+    if ((self=[super init])) {
+        _runCount = 0;
+        _trainCount = 0;
+    }
+    return self;
+}
+
+- (BOOL)load:(NSError**)error {
+    return YES;
+}
+
+- (void)unload {
+
+}
+
+- (id<TIOData>)runOn:(id<TIOData>)input {
+    _runCount++;
+    
+    // Dummy value
+    return @{};
+}
+
+- (id<TIOLayerDescription>)descriptionOfInputAtIndex:(NSUInteger)index {
+    // Dummy value
+    return [[TIOVectorLayerDescription alloc] initWithShape:@[] batched:NO dtype:(TIODataTypeFloat32) labels:nil quantized:NO quantizer:nil dequantizer:nil];
+}
+- (id<TIOLayerDescription>)descriptionOfInputWithName:(NSString*)name {
+    // Dummy value
+    return [[TIOVectorLayerDescription alloc] initWithShape:@[] batched:NO dtype:(TIODataTypeFloat32) labels:nil quantized:NO quantizer:nil dequantizer:nil];
+}
+- (id<TIOLayerDescription>)descriptionOfOutputAtIndex:(NSUInteger)index {
+    // Dummy value
+    return [[TIOVectorLayerDescription alloc] initWithShape:@[] batched:NO dtype:(TIODataTypeFloat32) labels:nil quantized:NO quantizer:nil dequantizer:nil];
+}
+- (id<TIOLayerDescription>)descriptionOfOutputWithName:(NSString*)name {
+    // Dummy value
+    return [[TIOVectorLayerDescription alloc] initWithShape:@[] batched:NO dtype:(TIODataTypeFloat32) labels:nil quantized:NO quantizer:nil dequantizer:nil];
+}
+
+- (id<TIOData>)train:(TIOBatch*)batch {
+    _trainCount++;
+    
+    // Dummy value
+    return @{};
+}
+
+- (BOOL)exportTo:(NSURL*)fileURL error:(NSError**)error {
+    return YES;
+}
+
+@end

--- a/Example/Tests/TIOModelTrainerTests.m
+++ b/Example/Tests/TIOModelTrainerTests.m
@@ -1,0 +1,236 @@
+//
+//  TIOModelTrainerTests.m
+//  TensorIO_Tests
+//
+//  Created by Phil Dow on 5/20/19.
+//  Copyright © 2019 doc.ai (http://doc.ai)
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <XCTest/XCTest.h>
+#import <TensorIO/TensorIO-umbrella.h>
+#import "TIOMockBatchDataSource.h"
+#import "TIOMockTrainableModel.h"
+
+@interface TIOModelTrainerTests : XCTestCase
+
+@end
+
+@implementation TIOModelTrainerTests
+
+- (void)setUp {
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+}
+
+- (void)testBaseCaseWithOneItemOneEpochBatchSizeOfOne {
+    TIOMockBatchDataSource *dataSource = [[TIOMockBatchDataSource alloc] initWithItemCount:1];
+    TIOMockTrainableModel *model = [[TIOMockTrainableModel alloc] initMock];
+    
+    XCTAssertNotNil(dataSource);
+    XCTAssertNotNil(model);
+    
+    TIOModelTrainer *trainer = [[TIOModelTrainer alloc] initWithModel:model dataSource:dataSource placeholders:nil epochs:1 batchSize:1];
+    
+    [trainer train];
+    
+    XCTAssert(model.trainCount == 1);
+    XCTAssert([dataSource itemAtIndexCountAtIndex:0] == 1);
+}
+
+- (void)testOneItemOneEpochBatchSizeOfTwo {
+    TIOMockBatchDataSource *dataSource = [[TIOMockBatchDataSource alloc] initWithItemCount:1];
+    TIOMockTrainableModel *model = [[TIOMockTrainableModel alloc] initMock];
+    
+    XCTAssertNotNil(dataSource);
+    XCTAssertNotNil(model);
+    
+    TIOModelTrainer *trainer = [[TIOModelTrainer alloc] initWithModel:model dataSource:dataSource placeholders:nil epochs:1 batchSize:1];
+    
+    [trainer train];
+    
+    XCTAssert(model.trainCount == 1);
+    XCTAssert([dataSource itemAtIndexCountAtIndex:0] == 1);
+}
+
+- (void)testOneItemTwoEpochsBatchSizeOfOne {
+    TIOMockBatchDataSource *dataSource = [[TIOMockBatchDataSource alloc] initWithItemCount:1];
+    TIOMockTrainableModel *model = [[TIOMockTrainableModel alloc] initMock];
+    
+    XCTAssertNotNil(dataSource);
+    XCTAssertNotNil(model);
+    
+    TIOModelTrainer *trainer = [[TIOModelTrainer alloc] initWithModel:model dataSource:dataSource placeholders:nil epochs:2 batchSize:1];
+    
+    [trainer train];
+    
+    XCTAssert(model.trainCount == 2);
+    XCTAssert([dataSource itemAtIndexCountAtIndex:0] == 2);
+}
+
+- (void)testTwoItemsOneEpochBatchSizeOfOne {
+    TIOMockBatchDataSource *dataSource = [[TIOMockBatchDataSource alloc] initWithItemCount:2];
+    TIOMockTrainableModel *model = [[TIOMockTrainableModel alloc] initMock];
+    
+    XCTAssertNotNil(dataSource);
+    XCTAssertNotNil(model);
+    
+    TIOModelTrainer *trainer = [[TIOModelTrainer alloc] initWithModel:model dataSource:dataSource placeholders:nil epochs:1 batchSize:1];
+    
+    [trainer train];
+    
+    XCTAssert(model.trainCount == 2);
+    XCTAssert([dataSource itemAtIndexCountAtIndex:0] == 1);
+    XCTAssert([dataSource itemAtIndexCountAtIndex:1] == 1);
+}
+
+- (void)testTwoItemsTwoEpochsBatchSizeOfOne {
+    TIOMockBatchDataSource *dataSource = [[TIOMockBatchDataSource alloc] initWithItemCount:2];
+    TIOMockTrainableModel *model = [[TIOMockTrainableModel alloc] initMock];
+    
+    XCTAssertNotNil(dataSource);
+    XCTAssertNotNil(model);
+    
+    TIOModelTrainer *trainer = [[TIOModelTrainer alloc] initWithModel:model dataSource:dataSource placeholders:nil epochs:2 batchSize:1];
+    
+    [trainer train];
+    
+    XCTAssert(model.trainCount == 4);
+    XCTAssert([dataSource itemAtIndexCountAtIndex:0] == 2);
+    XCTAssert([dataSource itemAtIndexCountAtIndex:1] == 2);
+}
+
+- (void)testTwoItemsTwoEpochBatchSizeOfTwo {
+    TIOMockBatchDataSource *dataSource = [[TIOMockBatchDataSource alloc] initWithItemCount:2];
+    TIOMockTrainableModel *model = [[TIOMockTrainableModel alloc] initMock];
+    
+    XCTAssertNotNil(dataSource);
+    XCTAssertNotNil(model);
+    
+    TIOModelTrainer *trainer = [[TIOModelTrainer alloc] initWithModel:model dataSource:dataSource placeholders:nil epochs:2 batchSize:2];
+    
+    [trainer train];
+    
+    XCTAssert(model.trainCount == 2);
+    XCTAssert([dataSource itemAtIndexCountAtIndex:0] == 2);
+    XCTAssert([dataSource itemAtIndexCountAtIndex:1] == 2);
+}
+
+- (void)testThreeItemsOneEpochBatchSizeOfOne {
+    TIOMockBatchDataSource *dataSource = [[TIOMockBatchDataSource alloc] initWithItemCount:3];
+    TIOMockTrainableModel *model = [[TIOMockTrainableModel alloc] initMock];
+    
+    XCTAssertNotNil(dataSource);
+    XCTAssertNotNil(model);
+    
+    TIOModelTrainer *trainer = [[TIOModelTrainer alloc] initWithModel:model dataSource:dataSource placeholders:nil epochs:1 batchSize:1];
+    
+    [trainer train];
+    
+    XCTAssert(model.trainCount == 3);
+    XCTAssert([dataSource itemAtIndexCountAtIndex:0] == 1);
+    XCTAssert([dataSource itemAtIndexCountAtIndex:1] == 1);
+    XCTAssert([dataSource itemAtIndexCountAtIndex:2] == 1);
+}
+
+- (void)testThreeItemsOneEpochBatchSizeOfTwo {
+    TIOMockBatchDataSource *dataSource = [[TIOMockBatchDataSource alloc] initWithItemCount:3];
+    TIOMockTrainableModel *model = [[TIOMockTrainableModel alloc] initMock];
+    
+    XCTAssertNotNil(dataSource);
+    XCTAssertNotNil(model);
+    
+    TIOModelTrainer *trainer = [[TIOModelTrainer alloc] initWithModel:model dataSource:dataSource placeholders:nil epochs:1 batchSize:2];
+    
+    [trainer train];
+    
+    XCTAssert(model.trainCount == 2);
+    XCTAssert([dataSource itemAtIndexCountAtIndex:0] == 1);
+    XCTAssert([dataSource itemAtIndexCountAtIndex:1] == 1);
+    XCTAssert([dataSource itemAtIndexCountAtIndex:2] == 1);
+}
+
+- (void)testThreeItemsOneEpochBatchSizeOfThree {
+    TIOMockBatchDataSource *dataSource = [[TIOMockBatchDataSource alloc] initWithItemCount:3];
+    TIOMockTrainableModel *model = [[TIOMockTrainableModel alloc] initMock];
+    
+    XCTAssertNotNil(dataSource);
+    XCTAssertNotNil(model);
+    
+    TIOModelTrainer *trainer = [[TIOModelTrainer alloc] initWithModel:model dataSource:dataSource placeholders:nil epochs:1 batchSize:3];
+    
+    [trainer train];
+    
+    XCTAssert(model.trainCount == 1);
+    XCTAssert([dataSource itemAtIndexCountAtIndex:0] == 1);
+    XCTAssert([dataSource itemAtIndexCountAtIndex:1] == 1);
+    XCTAssert([dataSource itemAtIndexCountAtIndex:2] == 1);
+}
+
+- (void)testThreeItemsTwoEpochsBatchSizeOfOne {
+    TIOMockBatchDataSource *dataSource = [[TIOMockBatchDataSource alloc] initWithItemCount:3];
+    TIOMockTrainableModel *model = [[TIOMockTrainableModel alloc] initMock];
+    
+    XCTAssertNotNil(dataSource);
+    XCTAssertNotNil(model);
+    
+    TIOModelTrainer *trainer = [[TIOModelTrainer alloc] initWithModel:model dataSource:dataSource placeholders:nil epochs:2 batchSize:1];
+    
+    [trainer train];
+    
+    XCTAssert(model.trainCount == 6);
+    XCTAssert([dataSource itemAtIndexCountAtIndex:0] == 2);
+    XCTAssert([dataSource itemAtIndexCountAtIndex:1] == 2);
+    XCTAssert([dataSource itemAtIndexCountAtIndex:2] == 2);
+}
+
+- (void)testThreeItemsTwoEpochsBatchSizeOfTwo {
+    TIOMockBatchDataSource *dataSource = [[TIOMockBatchDataSource alloc] initWithItemCount:3];
+    TIOMockTrainableModel *model = [[TIOMockTrainableModel alloc] initMock];
+    
+    XCTAssertNotNil(dataSource);
+    XCTAssertNotNil(model);
+    
+    TIOModelTrainer *trainer = [[TIOModelTrainer alloc] initWithModel:model dataSource:dataSource placeholders:nil epochs:2 batchSize:2];
+    
+    [trainer train];
+    
+    XCTAssert(model.trainCount == 4);
+    XCTAssert([dataSource itemAtIndexCountAtIndex:0] == 2);
+    XCTAssert([dataSource itemAtIndexCountAtIndex:1] == 2);
+    XCTAssert([dataSource itemAtIndexCountAtIndex:2] == 2);
+}
+
+- (void)testThreeItemsTwoEpochBatchSizeOfThree {
+    TIOMockBatchDataSource *dataSource = [[TIOMockBatchDataSource alloc] initWithItemCount:3];
+    TIOMockTrainableModel *model = [[TIOMockTrainableModel alloc] initMock];
+    
+    XCTAssertNotNil(dataSource);
+    XCTAssertNotNil(model);
+    
+    TIOModelTrainer *trainer = [[TIOModelTrainer alloc] initWithModel:model dataSource:dataSource placeholders:nil epochs:2 batchSize:3];
+    
+    [trainer train];
+    
+    XCTAssert(model.trainCount == 2);
+    XCTAssert([dataSource itemAtIndexCountAtIndex:0] == 2);
+    XCTAssert([dataSource itemAtIndexCountAtIndex:1] == 2);
+    XCTAssert([dataSource itemAtIndexCountAtIndex:2] == 2);
+}
+
+
+@end

--- a/TensorIO/Classes/Core/TIOData/TIOBatch.m
+++ b/TensorIO/Classes/Core/TIOData/TIOBatch.m
@@ -76,7 +76,7 @@
 }
 
 - (TIOBatchItem*)itemAtIndex:(NSUInteger)index {
-    assert(index < _items.count);
+    assert(index < self.count);
     
     NSMutableDictionary *item = [[NSMutableDictionary alloc] init];
     

--- a/TensorIO/Classes/Core/TIOData/TIOBatchDataSource.h
+++ b/TensorIO/Classes/Core/TIOData/TIOBatchDataSource.h
@@ -37,6 +37,12 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol TIOBatchDataSource <NSObject>
 
 /**
+ * The batch keys.
+ */
+
+@property (readonly) NSArray<NSString*> *keys;
+
+/**
  * The total number of items that will be vended by the data source.
  */
 

--- a/TensorIO/Classes/Core/TIOData/TIOInMemoryBatchDataSource.h
+++ b/TensorIO/Classes/Core/TIOData/TIOInMemoryBatchDataSource.h
@@ -24,11 +24,36 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ * A convenience data source when batch data is small enough to be loaded into
+ * memory at the same time. Provide it a batch of any size and it will handle
+ * the data source implementation. Provide this data source to a class such as
+ * `TIOModelTrainer`.
+ *
+ * It will typically not be possible to use an in-memory data source if you are
+ * working with image data, as only a few images can be loaded into memory
+ * simultaneously without encountering out of memory errors.
+ */
+
 @interface TIOInMemoryBatchDataSource : NSObject <TIOBatchDataSource>
+
+/**
+ * The batch this data source will vend.
+ */
 
 @property (readonly) TIOBatch *batch;
 
+/**
+ * Instantiates an in-memory data source from a batch.
+ */
+
 - (instancetype)initWithBatch:(TIOBatch*)batch NS_DESIGNATED_INITIALIZER;
+
+/**
+ * A convenience initializer when you only have a single batch item.
+ */
+
+- (instancetype)initWithItem:(TIOBatchItem*)item;
 
 /**
  * Use the designated initializer.
@@ -36,7 +61,25 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 
+// MARK: - TIOBatchDataSource
+
+/**
+ * The batch keys.
+ */
+
+@property (readonly) NSArray<NSString*> *keys;
+
+/**
+ * The total number of items that will be vended by the data source.
+ */
+
 - (NSUInteger)numberOfItems;
+
+/**
+ * The item at a given index. It is the responsibility of the data source to
+ * randomize item order (shuffle).
+ */
+
 - (TIOBatchItem*)itemAtIndex:(NSUInteger)index;
 
 @end

--- a/TensorIO/Classes/Core/TIOModel/TIOModelTrainer.h
+++ b/TensorIO/Classes/Core/TIOModel/TIOModelTrainer.h
@@ -22,16 +22,82 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@protocol TIOBatchDataSource;
+@protocol TIOTrainableModel;
+@protocol TIOData;
+
 /**
  * Responsible for actually executing training passes on a model, iterating
  * over a specified number of epochs and preparing batches of a specified size.
- * The trainer receives either a single batch for training or is instantiated
- * with a `TIOBatchDataSource` which will provide data as needed during the
- * training loop.
+ * The trainer receives is instantiated with a `TIOBatchDataSource` which will
+ * nprovide data as needed during the training loop.
  */
 
 @interface TIOModelTrainer : NSObject
 
+/**
+ * The model that will be trained.
+ */
+
+@property (readonly) id<TIOTrainableModel> model;
+
+/**
+ * A data source that will provide batch items.
+ */
+
+@property (readonly) id<TIOBatchDataSource> dataSource;
+
+/**
+ * A dictionary of placeholder values that will be injected into the underlying
+ * model. Except for the number of epochs and the batch size, hyperparameters
+ * are be passed into the model trainer via this property. Currently unuspported.
+ */
+
+@property (nullable, readonly) NSDictionary<NSString*, id<TIOData>> *placeholders;
+
+/**
+ * The number of training epochs.
+ */
+
+@property (readonly) NSUInteger epochs;
+
+/**
+ * The batch size to use for each training pass.
+ */
+
+@property (readonly) NSUInteger batchSize;
+
+/**
+ * Instantiates a `TIOModelTrainer` with the information required to exceute a
+ * training loop.
+ *
+ * @param model The model that will be trained.
+ * @param dataSource A data source that will provide batch items.
+ * @param placeholders A dictionary of placeholder values that will be injected
+ *  into the underlying model, e.g. hyperparameters. Currently unsupported.
+ * @param epochs The number of training epochs.
+ * @param batchSize The batch size to use for each training pass.
+ *
+ * @return TIOModelTrainer The trainer instance.
+ *
+ * @warning placeholders is currently unsupported.
+ */
+
+- (instancetype)initWithModel:(id<TIOTrainableModel>)model dataSource:(id<TIOBatchDataSource>)dataSource placeholders:(nullable NSDictionary<NSString*, id<TIOData>>*)placeholders epochs:(NSUInteger)epochs batchSize:(NSUInteger)batchSize NS_DESIGNATED_INITIALIZER;
+
+/**
+ * Use the designated initializer.
+ */
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/**
+ * Executes the training loop and returns the results.
+ */
+
+- (id<TIOData>)train;
+
 @end
 
 NS_ASSUME_NONNULL_END
+

--- a/TensorIO/Classes/Core/TIOModel/TIOModelTrainer.m
+++ b/TensorIO/Classes/Core/TIOModel/TIOModelTrainer.m
@@ -19,7 +19,69 @@
 //
 
 #import "TIOModelTrainer.h"
+#import "TIOBatchDataSource.h"
+#import "TIOTrainableModel.h"
+#import "TIOData.h"
 
 @implementation TIOModelTrainer
+
+- (instancetype)initWithModel:(id<TIOTrainableModel>)model dataSource:(id<TIOBatchDataSource>)dataSource placeholders:(NSDictionary<NSString*, id<TIOData>>*)placeholders epochs:(NSUInteger)epochs batchSize:(NSUInteger)batchSize {
+    if ((self=[super init])) {
+        _model = model;
+        _dataSource = dataSource;
+        _placeholders = placeholders;
+        _epochs = epochs;
+        _batchSize = batchSize;
+    }
+    return self;
+}
+
+- (id<TIOData>)train {
+    NSUInteger batchCount = self._batchCount;
+    id<TIOData> results;
+    
+    for ( NSUInteger epoch = 0; epoch < self.epochs; epoch++ ) {
+        for ( NSUInteger batchIndex = 0; batchIndex < batchCount; batchIndex++ ) {
+            TIOBatch *batch = [self _batchAtIndex:batchIndex];
+            results = [self.model train:batch];
+        }
+    }
+    
+    return results;
+}
+
+/**
+ * The total number of batches needed to feed all of the data source's item
+ * in chunks of the specified batch size.
+ */
+
+- (NSUInteger)_batchCount {
+    return (NSUInteger)ceilf((float)self.dataSource.numberOfItems / (float)self.batchSize);
+}
+
+/**
+ * Prepares a batch for the training pass.
+ */
+
+- (TIOBatch*)_batchAtIndex:(NSUInteger)index {
+    TIOBatch *batch = [[TIOBatch alloc] initWithKeys:self.dataSource.keys];
+    NSUInteger numberOfItems = self.dataSource.numberOfItems;
+    NSRange itemRange;
+    
+    NSUInteger start = index * self.batchSize;
+    
+    if ( (start + self.batchSize) > numberOfItems ) {
+        itemRange = NSMakeRange(start, start + self.batchSize - numberOfItems);
+    } else {
+        itemRange = NSMakeRange(start, self.batchSize);
+    }
+    
+    for ( NSUInteger itemIndex = itemRange.location; itemIndex < NSMaxRange(itemRange); itemIndex++ ) {
+        TIOBatchItem *item = [self.dataSource itemAtIndex:itemIndex];
+        [batch addItem:item];
+    }
+    
+    return batch;
+}
 
 @end


### PR DESCRIPTION
Only the last two commits are relevant to this PR, the previous ones merge a hot fix.

The `TIOModelTrainer` class encapsulates the information needed to run a training loop on a model and actually executes that loop, setting up batches and iterating over epochs.

The `TIOBatchDataSourceProtocol` uses an idiomatic iOS design pattern, the Data Source, to vend data to a trainer for batching. In cases where all the training data can be loaded into memory simultaneously the `TIOInMemoryBatchDataSource` is provided as a convenience.

Tests and mocks ensure these classes behave correctly.

Addresses https://github.com/doc-ai/tensorio-ios/issues/95