### PR TITLE
Automated end-to-end docker client-server tests (#110)

### DIFF
--- a/FederatedExample/FederatedExample.xcodeproj/project.pbxproj
+++ b/FederatedExample/FederatedExample.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		2AC7945CDD8FF54C5EBD5A7D /* Pods_FederatedExampleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E268EBEAAB7808A17C5DA2E9 /* Pods_FederatedExampleTests.framework */; };
 		CFD8D77A36D8D7900730D734 /* Pods_FederatedExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AFCC30B6B82DA5976BC3C5F /* Pods_FederatedExample.framework */; };
+		E33CC3A72299BB70007F4A7B /* DockerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E33CC3A62299BB70007F4A7B /* DockerTests.mm */; };
+		E33CC3AA2299CBD3007F4A7B /* build_scripts in Resources */ = {isa = PBXBuildFile; fileRef = E33CC3A92299CBD2007F4A7B /* build_scripts */; };
 		E3CC3452229874440017462D /* TIOFleaJobUploadTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E3CC3451229874440017462D /* TIOFleaJobUploadTests.mm */; };
 		E3CC34542298787A0017462D /* test-job-results.zip in Resources */ = {isa = PBXBuildFile; fileRef = E3CC3453229878790017462D /* test-job-results.zip */; };
 		E3D16AFB2295CDF300BA4346 /* TIOFederatedManagerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E3D16AFA2295CDF300BA4346 /* TIOFederatedManagerTests.mm */; };
@@ -56,6 +58,8 @@
 		8AFCC30B6B82DA5976BC3C5F /* Pods_FederatedExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FederatedExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB4B6F0277C83C841E725D72 /* Pods-FederatedExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FederatedExample.debug.xcconfig"; path = "Target Support Files/Pods-FederatedExample/Pods-FederatedExample.debug.xcconfig"; sourceTree = "<group>"; };
 		E268EBEAAB7808A17C5DA2E9 /* Pods_FederatedExampleTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FederatedExampleTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E33CC3A62299BB70007F4A7B /* DockerTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DockerTests.mm; sourceTree = "<group>"; };
+		E33CC3A92299CBD2007F4A7B /* build_scripts */ = {isa = PBXFileReference; lastKnownFileType = folder; path = build_scripts; sourceTree = SOURCE_ROOT; };
 		E3CC3451229874440017462D /* TIOFleaJobUploadTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TIOFleaJobUploadTests.mm; sourceTree = "<group>"; };
 		E3CC3453229878790017462D /* test-job-results.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = "test-job-results.zip"; sourceTree = "<group>"; };
 		E3D16AFA2295CDF300BA4346 /* TIOFederatedManagerTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TIOFederatedManagerTests.mm; sourceTree = "<group>"; };
@@ -136,6 +140,14 @@
 			path = Pods;
 			sourceTree = "<group>";
 		};
+		E33CC3A82299BB76007F4A7B /* DockerTests */ = {
+			isa = PBXGroup;
+			children = (
+				E33CC3A62299BB70007F4A7B /* DockerTests.mm */,
+			);
+			path = DockerTests;
+			sourceTree = "<group>";
+		};
 		E3CC34552298DCAC0017462D /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
@@ -192,6 +204,7 @@
 		E3E16D7822910BE60087197A /* FederatedExample */ = {
 			isa = PBXGroup;
 			children = (
+				E33CC3A92299CBD2007F4A7B /* build_scripts */,
 				E3E16D7922910BE60087197A /* AppDelegate.h */,
 				E3E16D7A22910BE60087197A /* AppDelegate.m */,
 				E3E16D7C22910BE60087197A /* ViewController.h */,
@@ -218,6 +231,7 @@
 				E3E16D9422910BE80087197A /* Info.plist */,
 				E3CC34552298DCAC0017462D /* Mocks */,
 				E3CC34562298DCD00017462D /* Tests */,
+				E33CC3A82299BB76007F4A7B /* DockerTests */,
 			);
 			path = FederatedExampleTests;
 			sourceTree = "<group>";
@@ -312,6 +326,7 @@
 				E3D16B1D229857DA00BA4346 /* test.tiotask.zip in Resources */,
 				E3E16DDF229477620087197A /* test.tiotask in Resources */,
 				E3E16D8322910BE80087197A /* Assets.xcassets in Resources */,
+				E33CC3AA2299CBD3007F4A7B /* build_scripts in Resources */,
 				E3E16D8122910BE60087197A /* Main.storyboard in Resources */,
 				E3D2BCD72295BE75004493C4 /* model-tests in Resources */,
 				E3D2BCDE2295C0FE004493C4 /* cat.jpg in Resources */,
@@ -439,6 +454,7 @@
 				E3D16B1B2298561100BA4346 /* TIOFleaTaskDownloadTests.mm in Sources */,
 				E3CC3452229874440017462D /* TIOFleaJobUploadTests.mm in Sources */,
 				E3E16DDD229476190087197A /* TIOFederatedTaskBundleTests.mm in Sources */,
+				E33CC3A72299BB70007F4A7B /* DockerTests.mm in Sources */,
 				E3D16B012295ED3500BA4346 /* TIOMockTrainableModel.mm in Sources */,
 				E3D16AFB2295CDF300BA4346 /* TIOFederatedManagerTests.mm in Sources */,
 				E3D16B042295ED8100BA4346 /* TIOMockFederatedManagerDataSourceProvider.mm in Sources */,

--- a/FederatedExample/FederatedExample.xcodeproj/xcshareddata/xcschemes/DockerTests.xcscheme
+++ b/FederatedExample/FederatedExample.xcodeproj/xcshareddata/xcschemes/DockerTests.xcscheme
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1020"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E3E16D7522910BE60087197A"
+               BuildableName = "FederatedExample.app"
+               BlueprintName = "FederatedExample"
+               ReferencedContainer = "container:FederatedExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "open $SRCROOT/build_scripts/start_docker.command || echo &quot;Unable to start docker image&quot;&#10;&#10;sleep 1&#10;&#10;open $SRCROOT/build_scripts/setup_mocks.command || echo &quot;Unable to set up test data&quot;&#10;"
+               shellToInvoke = "/bin/sh">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "E3E16D7522910BE60087197A"
+                     BuildableName = "FederatedExample.app"
+                     BlueprintName = "FederatedExample"
+                     ReferencedContainer = "container:FederatedExample.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            useTestSelectionWhitelist = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E3E16D8D22910BE80087197A"
+               BuildableName = "FederatedExampleTests.xctest"
+               BlueprintName = "FederatedExampleTests"
+               ReferencedContainer = "container:FederatedExample.xcodeproj">
+            </BuildableReference>
+            <SelectedTests>
+               <Test
+                  Identifier = "DockerTests/testExample">
+               </Test>
+               <Test
+                  Identifier = "DockerTests/testGETHealth">
+               </Test>
+               <Test
+                  Identifier = "DockerTests/testGETStartTask">
+               </Test>
+               <Test
+                  Identifier = "DockerTests/testGETTask">
+               </Test>
+               <Test
+                  Identifier = "DockerTests/testGetAllTasks">
+               </Test>
+               <Test
+                  Identifier = "DockerTests/testPerformanceExample">
+               </Test>
+            </SelectedTests>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E3E16D7522910BE60087197A"
+            BuildableName = "FederatedExample.app"
+            BlueprintName = "FederatedExample"
+            ReferencedContainer = "container:FederatedExample.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "# Type a script or drag a script file from your workspace to insert its path.&#10;">
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E3E16D7522910BE60087197A"
+            BuildableName = "FederatedExample.app"
+            BlueprintName = "FederatedExample"
+            ReferencedContainer = "container:FederatedExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E3E16D7522910BE60087197A"
+            BuildableName = "FederatedExample.app"
+            BlueprintName = "FederatedExample"
+            ReferencedContainer = "container:FederatedExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/FederatedExample/FederatedExample.xcodeproj/xcshareddata/xcschemes/FederatedExample.xcscheme
+++ b/FederatedExample/FederatedExample.xcodeproj/xcshareddata/xcschemes/FederatedExample.xcscheme
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1020"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E3E16D7522910BE60087197A"
+               BuildableName = "FederatedExample.app"
+               BlueprintName = "FederatedExample"
+               ReferencedContainer = "container:FederatedExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E3E16D8D22910BE80087197A"
+               BuildableName = "FederatedExampleTests.xctest"
+               BlueprintName = "FederatedExampleTests"
+               ReferencedContainer = "container:FederatedExample.xcodeproj">
+            </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "DockerTests">
+               </Test>
+            </SkippedTests>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E3E16D7522910BE60087197A"
+            BuildableName = "FederatedExample.app"
+            BlueprintName = "FederatedExample"
+            ReferencedContainer = "container:FederatedExample.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E3E16D7522910BE60087197A"
+            BuildableName = "FederatedExample.app"
+            BlueprintName = "FederatedExample"
+            ReferencedContainer = "container:FederatedExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E3E16D7522910BE60087197A"
+            BuildableName = "FederatedExample.app"
+            BlueprintName = "FederatedExample"
+            ReferencedContainer = "container:FederatedExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/FederatedExample/FederatedExample/ViewController.mm
+++ b/FederatedExample/FederatedExample/ViewController.mm
@@ -29,51 +29,6 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    // Install docker
-    // In tensorio-models: $ make run-flea
-    // In tensorio-models: $ ./e2e/create-sample-tasks.sh
-    
-    NSString *taskId = @"b7";
-    
-    NSURL *URL = [NSURL URLWithString:@"http://localhost:8083/v1/flea"];
-    TIOFleaClient *client = [[TIOFleaClient alloc] initWithBaseURL:URL session:nil];
-
-    [client GETHealthStatus:^(TIOFleaStatus * _Nullable response, NSError * _Nonnull error) {
-        if (error) {
-            NSLog(@"There was an error, %@", error);
-            return;
-        }
-
-        NSLog(@"HEALTH STATUS: %@", response);
-    }];
-    
-    [client GETTasksWithModelId:nil hyperparametersId:nil checkpointId:nil callback:^(TIOFleaTasks * _Nullable tasks, NSError * _Nullable error) {
-        if (error) {
-            NSLog(@"There was an error, %@", error);
-            return;
-        }
-
-        NSLog(@"Tasks are: %@", tasks);
-    }];
-
-    [client GETTaskWithTaskId:taskId callback:^(TIOFleaTask * _Nullable task, NSError * _Nullable error) {
-        if (error) {
-            NSLog(@"There was an error, %@", error);
-            return;
-        }
-
-        NSLog(@"Task is: %@", task);
-    }];
-
-    [client GETStartTaskWithTaskId:taskId callback:^(TIOFleaJob * _Nullable job, NSError * _Nullable error) {
-        if (error) {
-            NSLog(@"There was an error, %@", error);
-            return;
-        }
-
-        NSLog(@"Job is: %@", job);
-    }];
 }
-
 
 @end

--- a/FederatedExample/FederatedExampleTests/DockerTests/DockerTests.mm
+++ b/FederatedExample/FederatedExampleTests/DockerTests/DockerTests.mm
@@ -1,0 +1,102 @@
+//
+//  DockerTests.m
+//  FederatedExampleTests
+//
+//  Created by Phil Dow on 5/25/19.
+//  Copyright © 2019 doc.ai (http://doc.ai)
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <XCTest/XCTest.h>
+#import <TensorIO/TensorIO-umbrella.h>
+#import "MockURLSession.h"
+
+@interface DockerTests : XCTestCase
+
+@property TIOFleaClient *client;
+
+@end
+
+@implementation DockerTests
+
+- (void)setUp {
+    NSURL *URL = [NSURL URLWithString:@"http://localhost:8083/v1/flea"];
+    self.client = [[TIOFleaClient alloc] initWithBaseURL:URL session:nil];
+}
+
+- (void)tearDown { }
+
+- (void)testGETHealth {
+    XCTestExpectation *expectation = [[XCTestExpectation alloc] initWithDescription:@"Wait for health status response"];
+    
+    [self.client GETHealthStatus:^(TIOFleaStatus * _Nullable status, NSError * _Nonnull error) {
+        [expectation fulfill];
+        
+        XCTAssertNil(error);
+        XCTAssertNotNil(status);
+        
+        XCTAssert(status.status == TIOFleaStatusValueServing);
+    }];
+    
+    [self waitForExpectations:@[expectation] timeout:1.0];
+}
+
+- (void)testGetAllTasks {
+    XCTestExpectation *expectation = [[XCTestExpectation alloc] initWithDescription:@"Wait for all tasks response"];
+    
+    [self.client GETTasksWithModelId:nil hyperparametersId:nil checkpointId:nil callback:^(TIOFleaTasks * _Nullable tasks, NSError * _Nullable error) {
+        [expectation fulfill];
+        
+        XCTAssertNil(error);
+        XCTAssertNotNil(tasks);
+
+        NSLog(@"Tasks are: %@", tasks);
+    }];
+    
+    [self waitForExpectations:@[expectation] timeout:1.0];
+}
+
+- (void)testGETTask {
+    XCTestExpectation *expectation = [[XCTestExpectation alloc] initWithDescription:@"Wait for task response"];
+    NSString *taskId = @"b7"; // From mocks script
+    
+    [self.client GETTaskWithTaskId:taskId callback:^(TIOFleaTask * _Nullable task, NSError * _Nullable error) {
+        [expectation fulfill];
+        
+        XCTAssertNil(error);
+        XCTAssertNotNil(task);
+
+        NSLog(@"Task is: %@", task);
+    }];
+    
+    [self waitForExpectations:@[expectation] timeout:1.0];
+}
+
+- (void)testGETStartTask {
+    XCTestExpectation *expectation = [[XCTestExpectation alloc] initWithDescription:@"Wait for start task response"];
+    NSString *taskId = @"b7"; // From mocks script
+    
+    [self.client GETStartTaskWithTaskId:taskId callback:^(TIOFleaJob * _Nullable job, NSError * _Nullable error) {
+        [expectation fulfill];
+        
+        XCTAssertNil(error);
+        XCTAssertNotNil(job);
+
+        NSLog(@"Job is: %@", job);
+    }];
+    
+    [self waitForExpectations:@[expectation] timeout:1.0];
+}
+
+@end

--- a/FederatedExample/build_scripts/setup_mocks.command
+++ b/FederatedExample/build_scripts/setup_mocks.command
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+
+FLEA_DOCKER_PORT=8083
+
+# Set terminal title
+
+echo -en "\\033]0;TensorIO Flea Mocks\\a"
+clear
+
+# Wait for serving connection to the docker image
+
+while ! nc -z localhost $FLEA_DOCKER_PORT; do   
+  sleep 0.25
+done
+
+while ! curl -s http://localhost:$FLEA_DOCKER_PORT/v1/flea/healthz | grep "SERVING"; do
+  sleep 0.25
+done
+
+# tensorio-models directory
+
+if [[ -z "${TENSORIO_MODELS_DIR}" ]]; then
+  TENSORIO_MODELS_DIR=~/repos/tensorio-models/
+fi
+cd $TENSORIO_MODELS_DIR
+
+# start the docker image
+
+echo "**** Setting up mocks ****"
+./e2e/create-sample-tasks.sh

--- a/FederatedExample/build_scripts/start_docker.command
+++ b/FederatedExample/build_scripts/start_docker.command
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+FLEA_IMAGE=docai/tensorio-flea
+
+# Set terminal title
+
+echo -en "\\033]0;TensorIO Flea Docker\\a"
+clear
+
+# kill any currently running flea container
+
+if [ "$(docker ps -q --filter ancestor=$FLEA_IMAGE)" ]; then
+  docker stop $(docker ps -q --filter ancestor=$FLEA_IMAGE )
+fi
+
+# tensorio-models directory
+
+if [[ -z "${TENSORIO_MODELS_DIR}" ]]; then
+  TENSORIO_MODELS_DIR=~/repos/tensorio-models/
+fi
+cd $TENSORIO_MODELS_DIR
+
+# start the docker image
+
+echo "**** Starting docker image ****"
+make run-flea


### PR DESCRIPTION
From Xcode select DockerTests scheme and run tests. Pre-action scripts launch flea docker image and mock data scripts. Any previously running flea docker image is killed, guaranteeing clean test data.

Pretty cool.