### PR TITLE
Move Model IO parsing to bundle and encapsulate

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -19,165 +19,167 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		03460A08D4B8F948725438A513A89C09 /* TIOVisionPipeline.h in Headers */ = {isa = PBXBuildFile; fileRef = DE4D6998B93870B7EF452A01D27B8EB4 /* TIOVisionPipeline.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		053B3BE4AF56D86A947D30B2E75A7874 /* TIOPlaceholderModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 08232AC91EBA18DE368420CBDBB9ED07 /* TIOPlaceholderModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		076437423BD7E95B9EC79BB04A0011F0 /* TIOModelModes.h in Headers */ = {isa = PBXBuildFile; fileRef = ACCB05BBD0358B48619DFED40F5526D1 /* TIOModelModes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		042E5A2170436CD3003AED8B48CD8BD8 /* TIOPixelBuffer+TIOTFLiteData.mm in Sources */ = {isa = PBXBuildFile; fileRef = B1CC8AC479C0C0E2D99B3EB59841F8E9 /* TIOPixelBuffer+TIOTFLiteData.mm */; };
+		06AC87143DE611249A804C8F068495EF /* TIOModelTrainer.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E514BA373B228C7A602112F9E5FBB22 /* TIOModelTrainer.m */; };
 		085671851C35E86F160395486CF81DB9 /* DSJSONSchemaValidationOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A4518A8AD3D7A126D365A5428202BC1 /* DSJSONSchemaValidationOptions.m */; };
 		08B6E2B4439876A485993F2A094322B9 /* NSNumber+DSJSONNumberTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = C733C0FCB2756C52C374E50C7D3E5D3F /* NSNumber+DSJSONNumberTypes.m */; };
 		09810790938103BF9F0960ABA69CBC3A /* DSJSONSchemaConstValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = AC766550D4DD7B7DFC8B039FCB01FE91 /* DSJSONSchemaConstValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		09C1691387A0F23E32AC8BBC817DBA5E /* TIOModelBackend.mm in Sources */ = {isa = PBXBuildFile; fileRef = D188D3E48C328C26F5E2E445D21DA357 /* TIOModelBackend.mm */; };
 		0C65F25295BADA6758016FE2DDF126DF /* DSJSONSchemaValidationContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 994027DD6BD58936B1B636642AED21A9 /* DSJSONSchemaValidationContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0EA6E5857F45D0C166A8BF47D74A7AB8 /* Pods-TensorIO_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B98937D521A7CFFF683B050CAB2647EC /* Pods-TensorIO_Tests-dummy.m */; };
-		14460796BAEA6CCADC0316170D067BA5 /* TIOInMemoryBatchDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = DA7685F6495BFBE071CF6DA6316CC6E9 /* TIOInMemoryBatchDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0EFBE840B566D8FD6D15B7518B05F0DA /* TIOVectorLayerDescription.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACAC2BFDCDB4262D385E0CE747B859DF /* TIOVectorLayerDescription.mm */; };
+		0FFF86381236C826672265099E97C3C0 /* NSNumber+TIOTFLiteData.h in Headers */ = {isa = PBXBuildFile; fileRef = 8D745382255BB9F2E04559C7D61BE20F /* NSNumber+TIOTFLiteData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		11CA54688EF51A386632D9B30EBC2AAF /* TIOPlaceholderModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 171E4F6567BBD1751DCCC76E401CB857 /* TIOPlaceholderModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		14DB444382146D8A31E220837DC0D997 /* DSJSONSchema.m in Sources */ = {isa = PBXBuildFile; fileRef = D16A280AA243D5B012E723E787F4DE5A /* DSJSONSchema.m */; };
 		164BC4F6484BFE069D4DCE839CC4F3C3 /* DSJSONSchema+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = D7E25C93D7C555FCFCAAA46A85927590 /* DSJSONSchema+Protected.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1717FAED88B51C7ABCF52CB11BE08FEF /* DSJSONSchemaStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = C81372956AFFEE5A857744A74B89AA1D /* DSJSONSchemaStorage.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		174095403DDC224A5F89210ADE3C78A0 /* DSJSONSchemaContentValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F407729B295FDAF7ED82EC1536D5C70 /* DSJSONSchemaContentValidator.m */; };
-		19801A649693C1BDA189058A8B303044 /* TIOQuantization.mm in Sources */ = {isa = PBXBuildFile; fileRef = 75298E757529B7BAEB73DA8E8B771CFD /* TIOQuantization.mm */; };
-		1AB33B8DC84351DF28995A69419629B1 /* TIOVectorLayerDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 257ADCDB1753F2C7B4FECF243601BD9F /* TIOVectorLayerDescription.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		19A38997B40A1A0F6F02599BA4811F26 /* TIOVector.h in Headers */ = {isa = PBXBuildFile; fileRef = 93111DA57E1A44FD76A3F1DF8F2E2F17 /* TIOVector.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1B65DAC6CACF3D29ED2F00E00A29AD90 /* DSJSONSchemaFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = AB1014347D0A4F88366F1DB4493EC16B /* DSJSONSchemaFactory.m */; };
-		1C510FEBB471027435F06E94A9D73B99 /* TIOModelOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 84845BC02C859A1C5EB133C4C18982B2 /* TIOModelOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1D2BF4D383AF38FCBF5D621B2FE22101 /* NSDictionary+TIOExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E2C145CDEC1A4DA5BDE38BF9330B473 /* NSDictionary+TIOExtensions.m */; };
-		1E5C484CCBAD6ACB50271667E6853200 /* TIOPixelBufferLayerDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 40EFCD590CD6C96F21BC46E1986C686B /* TIOPixelBufferLayerDescription.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1C38EFF5F247EF221609A6C5A33FD77F /* TIOVisionModelHelpers.mm in Sources */ = {isa = PBXBuildFile; fileRef = 488EEAEA100720633633B4AD515BF635 /* TIOVisionModelHelpers.mm */; };
 		1EE04070D25951CBFABDBE1F68FA46AE /* DSJSONSchemaStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 67E5E8E761B7DBD4FE4204CCD2537D88 /* DSJSONSchemaStorage.m */; };
+		2151805A5A92461511C13E0699DF8775 /* TIOModelModes.h in Headers */ = {isa = PBXBuildFile; fileRef = 9965529B7F2F9D148615E43E9CC72FA4 /* TIOModelModes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		228042E2869B9A92AB22DDDCE781B98C /* UIImage+TIOCVPixelBufferExtensions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9CE44B70EE141089435FFA35C6245F5E /* UIImage+TIOCVPixelBufferExtensions.mm */; };
 		232FBF5818812E8359D7BAB3A52F44B7 /* DSJSONSchemaErrors.m in Sources */ = {isa = PBXBuildFile; fileRef = 83C9D326925212C994474ED505B45981 /* DSJSONSchemaErrors.m */; };
-		25CC22E35223D530FD29E2317218AE1F /* TensorIO-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = BA552F8AEB5FCF90B479ECBA489589E3 /* TensorIO-dummy.m */; };
-		26743750ACFCC5B94951723EE6AEE906 /* UIImage+TIOCVPixelBufferExtensions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2931B27637B78357AD2F30ACF9CFADE2 /* UIImage+TIOCVPixelBufferExtensions.mm */; };
+		241914046E99233A16D8B3EF7ADACD8B /* NSDictionary+TIOExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 51BD662550A0D4E9CCBD1DFF01BF492F /* NSDictionary+TIOExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		253703A23C5269DD770F90C24AF5671B /* TensorIO-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = BA552F8AEB5FCF90B479ECBA489589E3 /* TensorIO-dummy.m */; };
+		2799C2CEB29159DB1881F9DA3638E4EF /* TIOVisionPipeline.mm in Sources */ = {isa = PBXBuildFile; fileRef = DF98D51691CAE05C47FE68A73CD53C9D /* TIOVisionPipeline.mm */; };
 		297424E8717E48CAB6B3FEBBDA25C25F /* DSJSONSchemaFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 79EB36D6FA12771CD26C0489A1AAEA9C /* DSJSONSchemaFactory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2A8F9BAC38E5CD12D7F09CA73625BD0C /* TIOPixelBuffer.mm in Sources */ = {isa = PBXBuildFile; fileRef = BA30957630A6E7EDF48F1CA417F35F6B /* TIOPixelBuffer.mm */; };
-		2FCB3FB4E37DAD078886C6A24C5480E1 /* TIOCVPixelBufferHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E4BBE157085BE569926F4CE27BA7D45 /* TIOCVPixelBufferHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		30CDD84FCD484C37B6656245DCE92B00 /* TIOVectorLayerDescription.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2C30AEEAB1D62EE79285CC68710C89D4 /* TIOVectorLayerDescription.mm */; };
+		2AA2DD9BA06099C41315A6DAB5DDC654 /* TIOLayerDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E64779F0F5063EC47A67D36E8726584 /* TIOLayerDescription.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2E9B3A94FE269B992120AE65E812F588 /* TIOVectorLayerDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 561DDC84C41E47E27621941D243B299F /* TIOVectorLayerDescription.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		30E7A6214B878FDB11E3BFBE4E61F9FF /* DSJSONSchemaNumericValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = 8292CA810E124D501F5C8044173D36BD /* DSJSONSchemaNumericValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3123AD2DC9F2E5357776AC857EE1278D /* NSURL+DSJSONReferencing.h in Headers */ = {isa = PBXBuildFile; fileRef = 14D15FCAB375F6DE5950409B900C9B75 /* NSURL+DSJSONReferencing.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3211A43E4FBDF51EC8FE6986AC0C2DF8 /* TIOModelBundleManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 15448BF97A28DBF69DFC514576A15174 /* TIOModelBundleManager.m */; };
 		32280BBF268B9558F5BEE3E1DACB588D /* DSJSONSchemaDependenciesValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = 484F01267E6BD98886214138047D81B3 /* DSJSONSchemaDependenciesValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32CF69418021FDF1A5320AFD104D4A97 /* UIImage+TIOCVPixelBufferExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 00FC5E26402AC13E3BC3059439BFF469 /* UIImage+TIOCVPixelBufferExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		34F150BFA513EEA256A3EBD4EA5F3B34 /* NSArray+DSJSONComparison.m in Sources */ = {isa = PBXBuildFile; fileRef = B919D68BFF3361AD1138831E89C9112B /* NSArray+DSJSONComparison.m */; };
 		3743F7968A318E0252858C2F498C7C0F /* Pods-TensorIO_Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F4FFB9355A04511CAAA818CB6569EB7 /* Pods-TensorIO_Tests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		380A886AA55C2F59A61CE4E50B843C54 /* TIOTFLiteErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = 22A914127192F44DC30358853761049C /* TIOTFLiteErrors.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		38643ABB91E59A6CCBA72CCBE2E8D041 /* TIOModelBundle.mm in Sources */ = {isa = PBXBuildFile; fileRef = 95F03E661AFEACB9705CD90831866707 /* TIOModelBundle.mm */; };
 		388984DF6D007380C09B39DFDD54FB7B /* DSJSONSchemaConstValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = 6826B463DCA341D9F2338E0CAEEA9687 /* DSJSONSchemaConstValidator.m */; };
 		3A616AA59D449D136AB50A4325735BC8 /* DSJSONSchemaConditionalValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = C70C464B7CE3CA598B44DAFD64BA643C /* DSJSONSchemaConditionalValidator.m */; };
-		3B4F44B8E4A9F0BC3E86C8D17905AAB8 /* TIOTFLiteModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 146A39071FE0F99C5C63194FFA8E60B2 /* TIOTFLiteModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3A9DAD920B22EBD389E39D278698317E /* TIOModelBundleValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = 65DF071BD86CCDEC253EFE73A4D49263 /* TIOModelBundleValidator.m */; };
 		3BBCA4C82F3EE01D9E9E05A327354EDD /* DSJSONSchemaObjectValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FE37DCC031DE186B342972363690BF29 /* DSJSONSchemaObjectValidator.m */; };
-		3BC3F9A799674C4BC154502C9AC9A6C8 /* TIOModelTrainer.m in Sources */ = {isa = PBXBuildFile; fileRef = ABABE54931EFB2E3B42677136308869B /* TIOModelTrainer.m */; };
 		3C769D408B16D520FE4216059EBF40F7 /* DSJSONSchemaPropertyNamesValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = 964FB52F6F83C9D9F7D62A14E3C72002 /* DSJSONSchemaPropertyNamesValidator.m */; };
 		3CC4AF64351F6410F4F0C3B8BA6C2F21 /* DSJSONSchemaPropertyNamesValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = DC6B5B8D4D36AAE59F15414DF83522E4 /* DSJSONSchemaPropertyNamesValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		425D9851D0BD30EE44548D5EA8A66BC4 /* TIOCVPixelBufferHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = AD86CC15CDD02BF263092B111D6EAB84 /* TIOCVPixelBufferHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		47322B08D4E35A60E8341F4FC1B6FCF8 /* DSJSONDictionarySchema.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C7C371650201D6331306518F09A694B /* DSJSONDictionarySchema.m */; };
-		4764D12BCB3DE963211D144C9AA55F6D /* TIOModelBundleJSONSchema.h in Headers */ = {isa = PBXBuildFile; fileRef = 48E9A7946B912F93F1C727A4E4295647 /* TIOModelBundleJSONSchema.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		48653D0AD057C12CD6296EBD423DB1F6 /* TIOPixelBufferLayerDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 7D62A78D7C8B8C8C399E31A67914FCEF /* TIOPixelBufferLayerDescription.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		49327967D014251A95FB3B39800BFB3D /* DSJSONSchema.h in Headers */ = {isa = PBXBuildFile; fileRef = EA441579012F05E5A91A02F9CB23C556 /* DSJSONSchema.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4AA8668196B01C0C5EB1E3B624086A1B /* TIOPixelBuffer+TIOTFLiteData.h in Headers */ = {isa = PBXBuildFile; fileRef = 35E4644AD1B9382D548A9B36239F58EF /* TIOPixelBuffer+TIOTFLiteData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4AB5367D9478AD0508A0396DCB89E30E /* TIOBatch.m in Sources */ = {isa = PBXBuildFile; fileRef = A0F432C6C9E1E484DE72B8D9455DEBB0 /* TIOBatch.m */; };
+		4B30B53BED2D28633DE73182C48A0C59 /* NSNumber+TIOTFLiteData.mm in Sources */ = {isa = PBXBuildFile; fileRef = 15C1700652BBABF3B671AD63CEFC28F6 /* NSNumber+TIOTFLiteData.mm */; };
+		4BA9B13832E158B04280D3A2613A46DE /* NSDictionary+TIOTFLiteData.h in Headers */ = {isa = PBXBuildFile; fileRef = 737B8E140717225C0ACDB75BF8956F76 /* NSDictionary+TIOTFLiteData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4C2C46C57F3AB7432FEA55FF17D338E9 /* TIOLayerInterface.mm in Sources */ = {isa = PBXBuildFile; fileRef = C37E528F92992D33BB8415CF0351F5B7 /* TIOLayerInterface.mm */; };
+		4C301768A4CD17053F3D878C93E00571 /* TIOData.h in Headers */ = {isa = PBXBuildFile; fileRef = 61D8372A527875C76CD947585E988AB8 /* TIOData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4CCEEF119ED4138C240CE003D295C9E1 /* TIOInMemoryBatchDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 1CF7CBF12AC537EBB56EB16720A75504 /* TIOInMemoryBatchDataSource.m */; };
 		4DB14C9D7F675AD4FEBE3DDA4C3D2DE9 /* DSJSONSchemaValidation-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B40CF226259FCEA93759DE10EAC36D4 /* DSJSONSchemaValidation-dummy.m */; };
-		4F02DEF5B11711163383AB588ACD62D3 /* NSNumber+TIOTFLiteData.mm in Sources */ = {isa = PBXBuildFile; fileRef = 15C1700652BBABF3B671AD63CEFC28F6 /* NSNumber+TIOTFLiteData.mm */; };
-		4FCEABB32E4C94EE15C6BB99EA26F378 /* NSData+TIOTFLiteData.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5A29243DFFBBC028F0A88476183CF15E /* NSData+TIOTFLiteData.mm */; };
+		4F15783C3F88F315FDE5467411165652 /* TIOModelIO.h in Headers */ = {isa = PBXBuildFile; fileRef = 345C079CC22E10B62729859666F75556 /* TIOModelIO.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5041A4454CC1CABA2F0FFC072F4A412F /* DSJSONSchemaValidationOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = DF136A9E9B6673AB8A2DD6085E321A43 /* DSJSONSchemaValidationOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		505CC0F72EA91C2EE6A876D65AA9F841 /* TIOPlaceholderModel.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4F8FBFF34B833A12973761829B09FB4F /* TIOPlaceholderModel.mm */; };
 		50B7041CE9F1699C907FA1640CC8EA3F /* DSJSONSchemaObjectPropertiesValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = 6EE0F32DA5637643907AC106377FD5E2 /* DSJSONSchemaObjectPropertiesValidator.m */; };
 		5134E80FCDBF3FF27A2C298300CFBB3B /* DSJSONSchemaCombiningValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C33433F18B04CD1E8FB7CAA8A4ECA60 /* DSJSONSchemaCombiningValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		526FAF86B22BF492DC46947F254510CC /* TIOBatchDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F6AF9ACFC53AAA315F1122E283F2D8F /* TIOBatchDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		52E123DAEF6A0369B90899D2F2C38949 /* TIOModelOptions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7D2876D71DCF6304DDD3B167C72FA47C /* TIOModelOptions.mm */; };
 		52EE921FB120589474D083114E8124F4 /* model-schema.json in Resources */ = {isa = PBXBuildFile; fileRef = 311871CE9407DCE34C71F887964D8588 /* model-schema.json */; };
+		530A62A3E3EB8CEFFEE27D0CFE873B8A /* TIOTFLiteModel.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2C9AC358103F0967D0E30C1CF8AA3062 /* TIOTFLiteModel.mm */; };
 		5434DEA2441413783D3C8277C3F6CA10 /* DSJSONSchemaObjectValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = 60F96F120BA4B9ED9BB7335390BC6C52 /* DSJSONSchemaObjectValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		54817C1D073EDFF77772501242AAFF65 /* DSJSONSchema+StandardValidators.m in Sources */ = {isa = PBXBuildFile; fileRef = D9D51670A79DB90ADDA4A77633168A40 /* DSJSONSchema+StandardValidators.m */; };
-		55BF72D827AAA0FC7DA35C99A7DB1284 /* NSData+TIOTFLiteData.h in Headers */ = {isa = PBXBuildFile; fileRef = 57BE7D271C6C8F77932E49B5787B71F6 /* NSData+TIOTFLiteData.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5711EB3EC41E50FB4B095A91F5D89E61 /* TIOModelJSONParsing.mm in Sources */ = {isa = PBXBuildFile; fileRef = 37C9BF180B88013E01ECD079259AF88C /* TIOModelJSONParsing.mm */; };
-		573D79D266DE8EBB32BF4E6F9C3E12BA /* TIOModelBackend.h in Headers */ = {isa = PBXBuildFile; fileRef = F25EBD9F966E191071BD221D8B17F2CF /* TIOModelBackend.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		59873930FDC61D3FCC2959A61B229F67 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB4607EFCA7C5F75397649E792E2AFCB /* Foundation.framework */; };
-		5A543E503D8A8E82A6407C3740B71A25 /* TIOModelBundleValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = D3586280FCC045A0DE59A4E1496E9D12 /* TIOModelBundleValidator.m */; };
 		5B4ADEFCBBCEC7EE7B5EA53240755EC0 /* DSJSONSchemaCombiningValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = 6ECDA26A461255CAFAE8209E84970C5C /* DSJSONSchemaCombiningValidator.m */; };
-		5BB1A62C7890AA3333C5C2C1B46BCE65 /* TIOMeasurable.c in Sources */ = {isa = PBXBuildFile; fileRef = 5DB77F185C1E64A88B474AD6899CD5A0 /* TIOMeasurable.c */; };
+		5DDF934B52E1449027EBC2FBB6BC9915 /* TIOModelBundleJSONSchema.h in Headers */ = {isa = PBXBuildFile; fileRef = CE60198C154CFA63D4B7641C923B9600 /* TIOModelBundleJSONSchema.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5E34E47A153B47F19888D145262BEEE3 /* TensorIO-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = D46C9113371FD702664DED576ED3F0A7 /* TensorIO-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5E526DD02FDE63F843F482844CC50C44 /* NSString+DSJSONPointer.h in Headers */ = {isa = PBXBuildFile; fileRef = 93BB0B8163528EEBF6CA16E363689629 /* NSString+DSJSONPointer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5F2FEDEE8C411A29FFF77FDF41C4F867 /* DSJSONSchemaValidationContext.m in Sources */ = {isa = PBXBuildFile; fileRef = DC6172A0E102C6F3C782CC212D76623C /* DSJSONSchemaValidationContext.m */; };
-		6006792AAAD574F496EAE66528A6DFEA /* TIOTFLiteModel.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2C9AC358103F0967D0E30C1CF8AA3062 /* TIOTFLiteModel.mm */; };
+		60C943C09E0A04434E9D7F4618F476AC /* NSArray+TIOTFLiteData.h in Headers */ = {isa = PBXBuildFile; fileRef = DD75F743B69E72CD75D399F3B4F23F50 /* NSArray+TIOTFLiteData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		60DC8C0B09F9F5196273E1B79997A4D7 /* TIOPixelBuffer+TIOTFLiteData.h in Headers */ = {isa = PBXBuildFile; fileRef = 35E4644AD1B9382D548A9B36239F58EF /* TIOPixelBuffer+TIOTFLiteData.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		60EA0012A923112603155AFE0A72E1FF /* DSJSONSchemaArrayValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = 047B434619E41D1501E2C1B6E1DD9913 /* DSJSONSchemaArrayValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		61B685CEDBBE2A41D289FB4D0160644B /* TIOPixelBufferLayerDescription.mm in Sources */ = {isa = PBXBuildFile; fileRef = 984774D856B3F93C5782C008E20B631E /* TIOPixelBufferLayerDescription.mm */; };
+		619F9B032CA3B51B2E7476E3AD3522C8 /* TIOPixelNormalization.mm in Sources */ = {isa = PBXBuildFile; fileRef = 62ABFD920DEF23EBEA334F40ACF021B6 /* TIOPixelNormalization.mm */; };
+		61D2E18EE2A3E905622F8509E298E15F /* TIOPixelNormalization.h in Headers */ = {isa = PBXBuildFile; fileRef = F499745C30AB03F2F6D97C7FBC9AB8FF /* TIOPixelNormalization.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		640D854C0AFE108FB32F6B42CBC8D1AE /* DSJSONSchemaContainsValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = E9C6DDD9D4EECCF69FEB67E7F991A274 /* DSJSONSchemaContainsValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		64BA9B59E582E4B689BC36933CEB8288 /* DSJSONSchemaDependenciesValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A390F7A0456FCA123FB114E5F9EB71B /* DSJSONSchemaDependenciesValidator.m */; };
 		673129D13C0153A388ED93316F39AE61 /* DSJSONSchemaEnumValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = E31DB86FF5A4B976B76423983C1EC416 /* DSJSONSchemaEnumValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		67A67D40EB5075656E1BEBBA9B39D98A /* TIOTrainableModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F0B02B323F2A9532B3C4A5D9C1FBA2A /* TIOTrainableModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		691E70174F45B21E43FE0BA967660C20 /* DSJSONSchema+StandardValidators.h in Headers */ = {isa = PBXBuildFile; fileRef = BD05046F61D05DA6A3E391169AAC24AB /* DSJSONSchema+StandardValidators.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6979944AFA896BD6ADACB5650D53F0E4 /* TIOModelJSONParsing.h in Headers */ = {isa = PBXBuildFile; fileRef = DD4224967C7EB2DC049409086766ECA1 /* TIOModelJSONParsing.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6B2E8D16FEFC8CFA287C13F62AEFA3C9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB4607EFCA7C5F75397649E792E2AFCB /* Foundation.framework */; };
-		6BECE195777FD82193944F3E7600840B /* NSArray+TIOExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 865623008925A319771721C9A7027FF3 /* NSArray+TIOExtensions.m */; };
+		6B667FA32FCE07F82A0BF0158E7C5649 /* TIODataTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 925F922DB4C5C22FDC6309AD087D0117 /* TIODataTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6CBDAE4FEDEDE77B345394F901323CC6 /* NSDictionary+DSJSONComparison.h in Headers */ = {isa = PBXBuildFile; fileRef = 87AF76BCD9AB7B62CC9A6235443F9F45 /* NSDictionary+DSJSONComparison.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7066118FAD3985303E2AF073C63BE328 /* TIOTFLiteData.h in Headers */ = {isa = PBXBuildFile; fileRef = AA66D1E8654F1A338F058DB6002A60AA /* TIOTFLiteData.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		72B936A503C64738EED76435A275945B /* TIOModelBundle.h in Headers */ = {isa = PBXBuildFile; fileRef = D55CB150FF54A8915332948E39B3DA5E /* TIOModelBundle.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		780E1AFA86E13CFA9EA52B700832BE37 /* TIOModelBackend.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5A310238D9BB50260E75296E0962C2E8 /* TIOModelBackend.mm */; };
-		7A765DE61DBCF4FE6DDFB50DC21575D8 /* TIOInMemoryBatchDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B3C5FDE164E2EC70B3B68F74EFBB386 /* TIOInMemoryBatchDataSource.m */; };
-		7B9AF99336EC62D592F127308691409A /* NSArray+TIOTFLiteData.mm in Sources */ = {isa = PBXBuildFile; fileRef = 36328C15B073A55ACA4C13E746A638F2 /* NSArray+TIOTFLiteData.mm */; };
+		7586A375C9D7078848F93A4AB55E5B07 /* TIOModelJSONParsing.h in Headers */ = {isa = PBXBuildFile; fileRef = EFC200F970CBC2973C0F302DF8156181 /* TIOModelJSONParsing.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		75CC80474BDAD4CD0F35579B7CEB87F3 /* NSDictionary+TIOExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = C379F2E8032783409BA3A9480FDBFBB3 /* NSDictionary+TIOExtensions.m */; };
+		78C6E1686B5DAA385233A1492145B926 /* TIOModelBundle.h in Headers */ = {isa = PBXBuildFile; fileRef = B1240EC52BC84C904B2A0B2E4A84A25D /* TIOModelBundle.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		79F4F4539C2EAB9A38FCBD1179C9DC41 /* TIOVisionModelHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = B908F26163DA3B5E857002575B73BC24 /* TIOVisionModelHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7C060A07B7F0937A5710EC1B4EE39150 /* DSJSONSchemaErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = A031ABDFAD8F17AEB4761DD4593F3BFC /* DSJSONSchemaErrors.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7DCB0961C26B49B06355AF84EF4D1BEA /* TIOTrainableModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B498F76A3D666B715CE27D0C488F8DB /* TIOTrainableModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7ECDBF6E3AD986D2C911F5C422C39FBB /* NSDictionary+DSJSONDeepMutableCopy.m in Sources */ = {isa = PBXBuildFile; fileRef = 81BBEC1C97A400D0DAA0508B13B7583E /* NSDictionary+DSJSONDeepMutableCopy.m */; };
 		7F4E7CA9F56897D22E42759DA0B5D75B /* DSJSONSchemaContentValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E9A88B990932CA0A94839ECC307A348 /* DSJSONSchemaContentValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		80020ADFE108CD8AA00EAA593AC984ED /* TIOBatchDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 26461D7555F165F2428A537D659C17E9 /* TIOBatchDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		80397918DB465F9F86C014F16336EE4A /* DSJSONSchemaTypeValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = B63EFA829E5AB270D9A9DE8521163309 /* DSJSONSchemaTypeValidator.m */; };
-		80DE86579E9EC5706B2CC015B7967896 /* TIOPixelNormalization.mm in Sources */ = {isa = PBXBuildFile; fileRef = 248F28EEE048AF8D1A6118FB2DAFA1FE /* TIOPixelNormalization.mm */; };
-		83AD74EB3376A4E20783FB18133DEEC6 /* TIOCVPixelBufferHelpers.mm in Sources */ = {isa = PBXBuildFile; fileRef = EA4718AF6A23D74A35394709D538B437 /* TIOCVPixelBufferHelpers.mm */; };
-		844B2CDE92FB351BFD4235AEEE7987A4 /* TIOObjcDefer.h in Headers */ = {isa = PBXBuildFile; fileRef = 1931AF33B0349CCF76E35260C54A5B65 /* TIOObjcDefer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		818D54192A27B45DD06C3E726EAC7FA7 /* TIOModelBundleValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B0242F34609B94287F4A28E4E2C3ECA /* TIOModelBundleValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		849D7B731446CABF2C7A9AC9878828DE /* NSDictionary+TIOTFLiteData.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0DA873D20B3D7C76EF705EAFE24F94F2 /* NSDictionary+TIOTFLiteData.mm */; };
 		84E136F32075A2F6681ADE6B6F187B4D /* DSJSONSchemaStringValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = 5547FCE18BBE4C8103C69F1C4DD4D242 /* DSJSONSchemaStringValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A6B9056863C63B6DE98FCF282D4C44A /* NSDictionary+TIOTFLiteData.h in Headers */ = {isa = PBXBuildFile; fileRef = 737B8E140717225C0ACDB75BF8956F76 /* NSDictionary+TIOTFLiteData.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8BB2590B2BA4063DACA653DDF2D5E4CC /* TIOMeasurable.h in Headers */ = {isa = PBXBuildFile; fileRef = 01C4C1BC2F56AC77B0720DBE3A077290 /* TIOMeasurable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		87D28054F6854BDE3B2DE67DCC77A57F /* TIOBatch.h in Headers */ = {isa = PBXBuildFile; fileRef = 4036256BF9D6E52293BCCFB20D4C581E /* TIOBatch.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		89F6106C3EF93F00F1B79E89F80AD097 /* TIOPlaceholderModel.mm in Sources */ = {isa = PBXBuildFile; fileRef = D52FBF7DD03E71606E6A34F65CFC227B /* TIOPlaceholderModel.mm */; };
+		8B6FD08E02035857107D4E0B7016242C /* TIOPixelBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = EE5EA34FC299CF65D6C04CA42E9FDBAF /* TIOPixelBuffer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8C0DB24BAF74ACDE0CA1F1164E20C392 /* DSJSONSchemaConditionalValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = 837886896C99CD5772731632F36F3CD1 /* DSJSONSchemaConditionalValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8C4979148611CF015104F71D7FF6082B /* NSDictionary+TIOTFLiteData.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0DA873D20B3D7C76EF705EAFE24F94F2 /* NSDictionary+TIOTFLiteData.mm */; };
+		8C535D74329E0BC7EFA1B92D99904C66 /* TIOPixelBufferLayerDescription.mm in Sources */ = {isa = PBXBuildFile; fileRef = 21FBE58E706F386F77EF167DC2410AF4 /* TIOPixelBufferLayerDescription.mm */; };
 		8D3BD260828697D7D4FC47D30B99098A /* NSNumber+DSJSONNumberTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 43004BF7392D431922F11D5407D9F0F4 /* NSNumber+DSJSONNumberTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8D990980F4B21806789702FBF2ED2E36 /* NSData+TIOTFLiteData.h in Headers */ = {isa = PBXBuildFile; fileRef = 57BE7D271C6C8F77932E49B5787B71F6 /* NSData+TIOTFLiteData.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8DCD0A5D1089733333F8AE22E41CC79A /* NSString+DSJSONPointer.m in Sources */ = {isa = PBXBuildFile; fileRef = 25979639F5DA068313CF4D29EEC5DCBC /* NSString+DSJSONPointer.m */; };
 		8F50C95EFB99E051B34E7A02F734FED2 /* Pods-TensorIO_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B4E919AEE8A0080C78B312A97CF7C8C /* Pods-TensorIO_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		905695CE49758A9D2A291C8EEB33CCD6 /* TensorIO-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = D46C9113371FD702664DED576ED3F0A7 /* TensorIO-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		90CE6425CFF7400A3E2640C58C96E27B /* TIOErrorHandling.h in Headers */ = {isa = PBXBuildFile; fileRef = 3361AAC50D280D558D9271B7667B978B /* TIOErrorHandling.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		913E2ADD87FDFCB8A3C32F3A191E8473 /* TIOLayerInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F681275BD4351CA4D1FABC46DDAA8B1 /* TIOLayerInterface.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		91A425D3D819E3A93621203602A62B6F /* TIOPixelBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = C77B8BF799B142E6241A245F043F95A1 /* TIOPixelBuffer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9265C00A66731C621E0AB37948411B62 /* TIOModelModes.m in Sources */ = {isa = PBXBuildFile; fileRef = FB3D4AEFD60948210AA602FB14ECDDE4 /* TIOModelModes.m */; };
+		93D80604D25857B1B86F8ACFB5867138 /* TIOLayerInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D41A0F77B359442BD94598B08BB02E3 /* TIOLayerInterface.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		94C79B18908A944CBB3438B4C3ADA702 /* DSJSONSchemaValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = C33AD2EA7F90B5D204CC90270C088DC2 /* DSJSONSchemaValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		94F401A62E4DCFA5FBF9DB091BA93622 /* DSJSONSchemaReference.h in Headers */ = {isa = PBXBuildFile; fileRef = CCD354C71ABD6F3D27E10F5D0A506079 /* DSJSONSchemaReference.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9805AB007FC2DFF572023A31DD5B82E1 /* NSDictionary+TIOExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C1EE7C7619646CBE79BAD9792FF9BC5 /* NSDictionary+TIOExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9A25BC69CC2E1283D3C759363D4141F1 /* TIOTFLiteErrors.mm in Sources */ = {isa = PBXBuildFile; fileRef = F8EFA6D531B78F0CCA4B5E3926FEF5D1 /* TIOTFLiteErrors.mm */; };
+		95BC48719546776E014C9D3BC6EA8BEA /* TIOTFLiteData.h in Headers */ = {isa = PBXBuildFile; fileRef = AA66D1E8654F1A338F058DB6002A60AA /* TIOTFLiteData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		99BE15A50E56DDA54E93E1723F509E04 /* TIOTFLiteModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 146A39071FE0F99C5C63194FFA8E60B2 /* TIOTFLiteModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9B1D7E7BAB75324DFA9256511C62DF81 /* DSJSONSchemaSpecification.m in Sources */ = {isa = PBXBuildFile; fileRef = 7405CD71B4A834C8899E5D961343A77E /* DSJSONSchemaSpecification.m */; };
 		9B5FF1F63DC73F80421983CA94EBEDF4 /* DSJSONSchemaDefinitions.m in Sources */ = {isa = PBXBuildFile; fileRef = AC45932608C29BCA59DC2A6BF40E4473 /* DSJSONSchemaDefinitions.m */; };
+		9BB9B978BBD4A7BB0552D94F1ACF83A3 /* TIOTFLiteErrors.mm in Sources */ = {isa = PBXBuildFile; fileRef = F8EFA6D531B78F0CCA4B5E3926FEF5D1 /* TIOTFLiteErrors.mm */; };
+		9C0907B867CEA55A96A9CBE2EA07A21B /* TIOQuantization.mm in Sources */ = {isa = PBXBuildFile; fileRef = 404510489D0B67BA126235BD3B02291D /* TIOQuantization.mm */; };
 		9C17141ACEB4B083FF2B79EC3755DD9C /* DSJSONSchemaContainsValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = 82217187198121495E9DCE6C4580A35E /* DSJSONSchemaContainsValidator.m */; };
 		9C70A2D581D2C904A3DA51DCF61E7E48 /* NSDictionary+DSJSONComparison.m in Sources */ = {isa = PBXBuildFile; fileRef = 1579EE49E910EE34843C83DEB8A8FBFB /* NSDictionary+DSJSONComparison.m */; };
 		9D93CDF2D616B973B1D79FFC71CEE193 /* DSJSONSchemaSpecification.h in Headers */ = {isa = PBXBuildFile; fileRef = A6B1B2FE3AB45E7156C68F1BC29B804D /* DSJSONSchemaSpecification.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9DD9DBB530EA0A60C6F2EC30C0406231 /* TIOMeasurable.h in Headers */ = {isa = PBXBuildFile; fileRef = F29CDD2FFF600831757CF6E9D030EF9D /* TIOMeasurable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9DFF114B96C22E7F6D198E443EB3750E /* TIOModelBackend.h in Headers */ = {isa = PBXBuildFile; fileRef = 6389DA7E1F0C76355032516E99CABB80 /* TIOModelBackend.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A0DDD1FB97E59DAC8556214F5E242BD7 /* DSJSONSchemaFormatValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = BD2D90CEEBD6704AD099CB8167B16E9F /* DSJSONSchemaFormatValidator.m */; };
+		A1B23108EE0FF78D0BEE59655EC7A0CA /* TIOInMemoryBatchDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 3E8584567A6D6603125D133B525DCDF0 /* TIOInMemoryBatchDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A1B494E813779B0B619AAFED85CA5777 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB4607EFCA7C5F75397649E792E2AFCB /* Foundation.framework */; };
-		A24827388EC4CB7FE0377EB53A75B106 /* TIOBatch.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F52BCEC91138320B52D4B3A3D970D41 /* TIOBatch.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A6DB09610CFFD19EE42732411D3903A6 /* DSJSONSchemaFormatValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = 4264E268688085CDFCE691D722E63606 /* DSJSONSchemaFormatValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A95A241242C43E0D67ABD7EC364A11A8 /* TIOModelJSONParsing.mm in Sources */ = {isa = PBXBuildFile; fileRef = E71D628000D7431A7E3236CF63463403 /* TIOModelJSONParsing.mm */; };
 		AA00C1402EC716BA2A1277B4160BF0C8 /* DSJSONSchemaObjectPropertiesValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = 3E9170713FF4B5798F31BAB3C2C11BAE /* DSJSONSchemaObjectPropertiesValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA81AB90CB4BC89B60516E96A44BAEA7 /* TIOTFLiteErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = 22A914127192F44DC30358853761049C /* TIOTFLiteErrors.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AC7144BFCACAEE948F2014909D9F2C5D /* NSObject+DSJSONComparison.h in Headers */ = {isa = PBXBuildFile; fileRef = E8DDE30713377D895262B1C4E3897902 /* NSObject+DSJSONComparison.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AD9C51FA9F300C21B6579056C34DFA4D /* DSJSONSchemaArrayItemsValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = 609C362DAA73453B7A8A700F627C01C2 /* DSJSONSchemaArrayItemsValidator.m */; };
 		AEA8632A9483B787A94A14B9A2BED099 /* NSObject+DSJSONComparison.m in Sources */ = {isa = PBXBuildFile; fileRef = BEF9799384BEBB5582D700D18474A223 /* NSObject+DSJSONComparison.m */; };
 		AEC3271D363F16E16DCF06495E122F69 /* DSJSONSchemaArrayItemsValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = E51F77FAF20A2DC41DEAFB4CC66C165E /* DSJSONSchemaArrayItemsValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B0A08DB6038ADD243611FB8C55CEC397 /* TIOModelTrainer.h in Headers */ = {isa = PBXBuildFile; fileRef = 802D8B32645EC9F1C4C7E8860BD0148C /* TIOModelTrainer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B1267ABBE38506CC819EF1DDFC53ED66 /* TIOErrorHandling.h in Headers */ = {isa = PBXBuildFile; fileRef = A973795713225C533435B1C38B1B4A68 /* TIOErrorHandling.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B1731A8AB5A87A57E6CCD19C349D003F /* DSJSONSchemaStringValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = BA8D26E871C50F7E16BCC12BD89B80E5 /* DSJSONSchemaStringValidator.m */; };
 		B1E5E7C39A617E43FF321CCEBDC0D04B /* DSJSONSchemaNumericValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = A90E6B56683D59B909669FD729180F15 /* DSJSONSchemaNumericValidator.m */; };
-		B203B236EB0DCEDDFE8565CA05CBD481 /* TIOData.h in Headers */ = {isa = PBXBuildFile; fileRef = 0984B9D1E5550F7E5761B5C84E3A4B73 /* TIOData.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B2CDEF648454CF28D1858E53FC47F17E /* TIOPixelBuffer+TIOTFLiteData.mm in Sources */ = {isa = PBXBuildFile; fileRef = B1CC8AC479C0C0E2D99B3EB59841F8E9 /* TIOPixelBuffer+TIOTFLiteData.mm */; };
+		B338A915AD0ED1E16B9EDBB1EF75A40C /* TIOModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 0893DF6CB8C0B3252EEB56B27FDA90BC /* TIOModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B690F2902EE97C7BFDA1ADF6D89BB50E /* DSJSONSchemaArrayValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = 867BF343176E2FF5F09B26F879420649 /* DSJSONSchemaArrayValidator.m */; };
 		B71F43DBD11DC5D3F9A3890A4D31D758 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB4607EFCA7C5F75397649E792E2AFCB /* Foundation.framework */; };
-		B77D54375427D62C1F1D1CBDEEE12947 /* TIOModel.h in Headers */ = {isa = PBXBuildFile; fileRef = AA46A1C8FE974DAC38931A536BDB7915 /* TIOModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B80A043EBBF208990451949609DF0258 /* DSJSONBooleanSchema.h in Headers */ = {isa = PBXBuildFile; fileRef = 09B5D56CB3536462C3039DBAA04A4877 /* DSJSONBooleanSchema.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BE830E010A1587170EDE029D362ABF08 /* TIOLayerInterface.mm in Sources */ = {isa = PBXBuildFile; fileRef = C03139A1F9D3A648975896D205CD5957 /* TIOLayerInterface.mm */; };
-		C0E2AA05BFBCB58E9E14CE6AA8C3EDA6 /* TIOModelBundleManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 295C29DD5D4BAFC55F3136054EB01276 /* TIOModelBundleManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C19310364041505463AE4BC89F1969AF /* TIOObjcDefer.h in Headers */ = {isa = PBXBuildFile; fileRef = EDC7E5EBD2C346CEAB5EEF20BF7AE346 /* TIOObjcDefer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C2E033F2E3DE6067226B79BA4D0C3D31 /* TFLite.bundle in Resources */ = {isa = PBXBuildFile; fileRef = CF27E284C6F18582EDAAFC5CFF3197A8 /* TFLite.bundle */; };
-		C3579A8DA3C2BF82F86260A2C61C7DEF /* TIOModelBundleValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = B8494AEA6C62D8A1081811BFEAD7770A /* TIOModelBundleValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C4FD3BBB4AC81427E1E2C6060A0647FD /* NSArray+DSJSONComparison.h in Headers */ = {isa = PBXBuildFile; fileRef = 0974D2B8A3AF8673525365EA2C2666FC /* NSArray+DSJSONComparison.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C6A700DA4DE49D988445CC60AFDA9499 /* DSJSONSchemaValidation-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 38BEA87055C538ECE505D9A33584F5F1 /* DSJSONSchemaValidation-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C9ABD37ED09D9691509C9F3931D70EFA /* NSArray+TIOTFLiteData.h in Headers */ = {isa = PBXBuildFile; fileRef = DD75F743B69E72CD75D399F3B4F23F50 /* NSArray+TIOTFLiteData.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C9EF26731C659A13D8F91D1E79F11956 /* NSDictionary+DSJSONDeepMutableCopy.h in Headers */ = {isa = PBXBuildFile; fileRef = ACAA862797E37C913ACF382820FDC170 /* NSDictionary+DSJSONDeepMutableCopy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CA82030686A576943FD91E34B0FB1F87 /* TIOModelIO.m in Sources */ = {isa = PBXBuildFile; fileRef = 7777B0C279F9B1B52ECFC8BE4BA004C9 /* TIOModelIO.m */; };
 		CB56963B29450CB2D2F8F5C4FAA478EA /* NSURL+DSJSONReferencing.m in Sources */ = {isa = PBXBuildFile; fileRef = A442B276C8D7E40F87C8062B254384E3 /* NSURL+DSJSONReferencing.m */; };
+		CC6BA2A5F92949D73DE2BBC6E45C484E /* NSArray+TIOExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 16E9B17718508E6898D53527153E0C9A /* NSArray+TIOExtensions.m */; };
+		CEAFF2AA9B0485A361F2AC80A24001B7 /* TIOModelTrainer.h in Headers */ = {isa = PBXBuildFile; fileRef = 21FF5B0671044E40CE8827A2D02C52C8 /* TIOModelTrainer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D00ABA78489618C18EBFBD62F57A9B51 /* DSJSONSchemaReference.m in Sources */ = {isa = PBXBuildFile; fileRef = EFF0640823DC1E3229730544DC2B6688 /* DSJSONSchemaReference.m */; };
-		D33FA0A917E565C879B3352FDB1C1C91 /* TIOVisionModelHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 52A3C3041378F88DE997373F11FA97E2 /* TIOVisionModelHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DA724C89488D77BDFFDC58AA3E7D0A1E /* TIOVector.h in Headers */ = {isa = PBXBuildFile; fileRef = EF9542A84034CCA72DF9F0CE29DE12F0 /* TIOVector.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DEE1B9BE63154B6F253930DE6619C9AF /* DSJSONSchemaTypeValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = 9636F6E581E203C2629FF74C6895ACD0 /* DSJSONSchemaTypeValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E3C05EB7DD1AF14693EB8168DE55B3CD /* TIOPixelNormalization.h in Headers */ = {isa = PBXBuildFile; fileRef = B58C7B1182B04856DE6B08A42E0B0AC7 /* TIOPixelNormalization.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E51F171A33E6149E98E0AD25DCBCFAEA /* NSArray+TIOExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 688312FAD412DEA7235AC8BEFC27123A /* NSArray+TIOExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E6BFDD05276A525CF0F88B87F174C62F /* TIOLayerDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = D3DE9D7D6E748E82A15D4696F61A6AFA /* TIOLayerDescription.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E86D3C07766F32FB9B3D5B7463AE1B57 /* TIOModelOptions.mm in Sources */ = {isa = PBXBuildFile; fileRef = D0BE675A97CD343800D6B8A07EE16EAF /* TIOModelOptions.mm */; };
-		EDF728A38FC31708ABE6E8EF96CA5A95 /* UIImage+TIOCVPixelBufferExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 32DCE98FFB913FE643621CF26E3CF055 /* UIImage+TIOCVPixelBufferExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E150719832F8301A438281890EF1D9F1 /* TIOModelModes.m in Sources */ = {isa = PBXBuildFile; fileRef = E5D8439D42464AA11776E4A0BC8E17F8 /* TIOModelModes.m */; };
+		E2DA0499B4E4D8BF8D9FD5E74F6781B2 /* TIOMeasurable.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F2F002881E91C36A26783A8C7092844 /* TIOMeasurable.c */; };
+		E559523E48CC0F9BB17427CD5ADCF9A3 /* TIOModelBundle.mm in Sources */ = {isa = PBXBuildFile; fileRef = F15A17521E1FAEC7C3A8171009D18268 /* TIOModelBundle.mm */; };
+		E6D71B7A8810A3C9781832E32586715A /* TIOVisionPipeline.h in Headers */ = {isa = PBXBuildFile; fileRef = 326539C23443CB202942A2D33168F3F8 /* TIOVisionPipeline.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E9FD59C64730F7DABB578BE46E5CB4A5 /* NSArray+TIOExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = E32D3694D251A4F13841D0E1496460B5 /* NSArray+TIOExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EECC59FB15BC5D10DC8FF2479AF28978 /* DSJSONDictionarySchema.h in Headers */ = {isa = PBXBuildFile; fileRef = 242191C32A17D5D80BB1039D3C807AB2 /* DSJSONDictionarySchema.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EF1EADA38858BEAF1926F622330F95E7 /* Pods-TensorIO_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B5EBE498695C4F88CF750EEE220DFD66 /* Pods-TensorIO_Example-dummy.m */; };
+		EF5EA65ADDFC993D9CBD8317BDC42EE2 /* TIOModelOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = CF194A5E8D223961F1C3E254218327C7 /* TIOModelOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EFAE9ECD216155B6155A3BFC1A8389A9 /* DSJSONSchemaEnumValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = AEE2329DE533E141B58131513AADC954 /* DSJSONSchemaEnumValidator.m */; };
 		F250DD3CADE80C5824702F445088EC76 /* DSJSONSchemaDefinitions.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F3ACE2A15977A6F4C8514496F15A0E7 /* DSJSONSchemaDefinitions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F6973BE2C4626EF3B9BB6235EA332A29 /* NSNumber+TIOTFLiteData.h in Headers */ = {isa = PBXBuildFile; fileRef = 8D745382255BB9F2E04559C7D61BE20F /* NSNumber+TIOTFLiteData.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F6CC65C1FC79A8AD9C484C60162DD652 /* TIOQuantization.h in Headers */ = {isa = PBXBuildFile; fileRef = 884A6D98E44249624BBA49B0C7C921AF /* TIOQuantization.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F328EF7C28404D9C6C9B9E9ECB19D13A /* NSData+TIOTFLiteData.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5A29243DFFBBC028F0A88476183CF15E /* NSData+TIOTFLiteData.mm */; };
+		F3DCF6BDEB41C24E88E8D10AACC8978D /* TIOModelBundleManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 494D1E8F1E2A3272C1D49E8532152EC2 /* TIOModelBundleManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FA0CC6984E23F5F244D6C1A0C48F214D /* DSJSONBooleanSchema.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B269D504E6438800C5FA61C44DF80DC /* DSJSONBooleanSchema.m */; };
-		FA70E36853AE08663573D66191446590 /* TIODataTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = C89230C1B6A2D5E4D8759048DC1F8FB0 /* TIODataTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FBE2B5F3B899FF743E5E999644F676B8 /* TIOBatch.m in Sources */ = {isa = PBXBuildFile; fileRef = 02C3623EA36D26C10AFB76087977DAED /* TIOBatch.m */; };
-		FC97000D18AE7F5DD58941ED46B8A004 /* TIOVisionPipeline.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7C6A110C61E7EAD73C595CD78F76BAA3 /* TIOVisionPipeline.mm */; };
-		FECBFE4171B5FF2D2425225788BBCB74 /* TIOVisionModelHelpers.mm in Sources */ = {isa = PBXBuildFile; fileRef = 26FC5C143CC91A1EF49381538F33C2E4 /* TIOVisionModelHelpers.mm */; };
-		FEE1B509BB0265286DACC11B2FBE8FF1 /* TIOModelBundleManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 376AC05902DE7A82CEE11DA34E084936 /* TIOModelBundleManager.m */; };
+		FA57519584BEF5C0CC7C22EA90A8215F /* NSArray+TIOTFLiteData.mm in Sources */ = {isa = PBXBuildFile; fileRef = 36328C15B073A55ACA4C13E746A638F2 /* NSArray+TIOTFLiteData.mm */; };
+		FC3F7D411144DF195C045113647FC7EE /* TIOQuantization.h in Headers */ = {isa = PBXBuildFile; fileRef = E94502CA422C9B40941887F209CEC6A6 /* TIOQuantization.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FC4C32B107718880B4664B2B698EE5F8 /* TIOPixelBuffer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5788DB34CA8C952C124B8B8DFDCDDB41 /* TIOPixelBuffer.mm */; };
+		FE53FCE64D1F18E866DC0C4A9EE15707 /* TIOCVPixelBufferHelpers.mm in Sources */ = {isa = PBXBuildFile; fileRef = A49DF966D6E9FB08A771ECA84DC96929 /* TIOCVPixelBufferHelpers.mm */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -233,14 +235,12 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		01C4C1BC2F56AC77B0720DBE3A077290 /* TIOMeasurable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOMeasurable.h; sourceTree = "<group>"; };
-		02C3623EA36D26C10AFB76087977DAED /* TIOBatch.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TIOBatch.m; sourceTree = "<group>"; };
+		00FC5E26402AC13E3BC3059439BFF469 /* UIImage+TIOCVPixelBufferExtensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UIImage+TIOCVPixelBufferExtensions.h"; sourceTree = "<group>"; };
 		047B434619E41D1501E2C1B6E1DD9913 /* DSJSONSchemaArrayValidator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSJSONSchemaArrayValidator.h; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaArrayValidator.h"; sourceTree = "<group>"; };
 		079E3A70C2330AB7603CA0BB216A6A32 /* Pods-TensorIO_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-TensorIO_Example-frameworks.sh"; sourceTree = "<group>"; };
-		08232AC91EBA18DE368420CBDBB9ED07 /* TIOPlaceholderModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOPlaceholderModel.h; sourceTree = "<group>"; };
+		0893DF6CB8C0B3252EEB56B27FDA90BC /* TIOModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOModel.h; sourceTree = "<group>"; };
 		09077E3E9F367FC773661DBF2BD61284 /* TensorIO-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "TensorIO-prefix.pch"; sourceTree = "<group>"; };
 		0974D2B8A3AF8673525365EA2C2666FC /* NSArray+DSJSONComparison.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSArray+DSJSONComparison.h"; path = "DSJSONSchemaValidation/Categories/NSArray+DSJSONComparison.h"; sourceTree = "<group>"; };
-		0984B9D1E5550F7E5761B5C84E3A4B73 /* TIOData.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOData.h; sourceTree = "<group>"; };
 		09B5D56CB3536462C3039DBAA04A4877 /* DSJSONBooleanSchema.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSJSONBooleanSchema.h; path = DSJSONSchemaValidation/DSJSONBooleanSchema.h; sourceTree = "<group>"; };
 		0BB34C6EBC413EF8E5AB24CC36E5887E /* Pods-TensorIO_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-TensorIO_Example.modulemap"; sourceTree = "<group>"; };
 		0DA873D20B3D7C76EF705EAFE24F94F2 /* NSDictionary+TIOTFLiteData.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = "NSDictionary+TIOTFLiteData.mm"; sourceTree = "<group>"; };
@@ -248,179 +248,183 @@
 		11E0F59285EFC412185874C02CD139DB /* Pods-TensorIO_Example-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-TensorIO_Example-resources.sh"; sourceTree = "<group>"; };
 		146A39071FE0F99C5C63194FFA8E60B2 /* TIOTFLiteModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOTFLiteModel.h; sourceTree = "<group>"; };
 		14D15FCAB375F6DE5950409B900C9B75 /* NSURL+DSJSONReferencing.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSURL+DSJSONReferencing.h"; path = "DSJSONSchemaValidation/Categories/NSURL+DSJSONReferencing.h"; sourceTree = "<group>"; };
+		15448BF97A28DBF69DFC514576A15174 /* TIOModelBundleManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TIOModelBundleManager.m; sourceTree = "<group>"; };
 		1579EE49E910EE34843C83DEB8A8FBFB /* NSDictionary+DSJSONComparison.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSDictionary+DSJSONComparison.m"; path = "DSJSONSchemaValidation/Categories/NSDictionary+DSJSONComparison.m"; sourceTree = "<group>"; };
 		15C1700652BBABF3B671AD63CEFC28F6 /* NSNumber+TIOTFLiteData.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = "NSNumber+TIOTFLiteData.mm"; sourceTree = "<group>"; };
-		1931AF33B0349CCF76E35260C54A5B65 /* TIOObjcDefer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOObjcDefer.h; sourceTree = "<group>"; };
+		16E9B17718508E6898D53527153E0C9A /* NSArray+TIOExtensions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSArray+TIOExtensions.m"; sourceTree = "<group>"; };
+		171E4F6567BBD1751DCCC76E401CB857 /* TIOPlaceholderModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOPlaceholderModel.h; sourceTree = "<group>"; };
 		1B269D504E6438800C5FA61C44DF80DC /* DSJSONBooleanSchema.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSJSONBooleanSchema.m; path = DSJSONSchemaValidation/DSJSONBooleanSchema.m; sourceTree = "<group>"; };
-		1E2C145CDEC1A4DA5BDE38BF9330B473 /* NSDictionary+TIOExtensions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+TIOExtensions.m"; sourceTree = "<group>"; };
+		1CF7CBF12AC537EBB56EB16720A75504 /* TIOInMemoryBatchDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TIOInMemoryBatchDataSource.m; sourceTree = "<group>"; };
+		21FBE58E706F386F77EF167DC2410AF4 /* TIOPixelBufferLayerDescription.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOPixelBufferLayerDescription.mm; sourceTree = "<group>"; };
+		21FF5B0671044E40CE8827A2D02C52C8 /* TIOModelTrainer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOModelTrainer.h; sourceTree = "<group>"; };
 		22A914127192F44DC30358853761049C /* TIOTFLiteErrors.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOTFLiteErrors.h; sourceTree = "<group>"; };
 		242191C32A17D5D80BB1039D3C807AB2 /* DSJSONDictionarySchema.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSJSONDictionarySchema.h; path = DSJSONSchemaValidation/DSJSONDictionarySchema.h; sourceTree = "<group>"; };
-		248F28EEE048AF8D1A6118FB2DAFA1FE /* TIOPixelNormalization.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOPixelNormalization.mm; sourceTree = "<group>"; };
-		257ADCDB1753F2C7B4FECF243601BD9F /* TIOVectorLayerDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOVectorLayerDescription.h; sourceTree = "<group>"; };
 		25979639F5DA068313CF4D29EEC5DCBC /* NSString+DSJSONPointer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSString+DSJSONPointer.m"; path = "DSJSONSchemaValidation/Categories/NSString+DSJSONPointer.m"; sourceTree = "<group>"; };
 		261C5CC4757F0A967A5F852E4AC25AF9 /* Pods_TensorIO_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_TensorIO_Tests.framework; path = "Pods-TensorIO_Tests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		26461D7555F165F2428A537D659C17E9 /* TIOBatchDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOBatchDataSource.h; sourceTree = "<group>"; };
-		26FC5C143CC91A1EF49381538F33C2E4 /* TIOVisionModelHelpers.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOVisionModelHelpers.mm; sourceTree = "<group>"; };
-		2931B27637B78357AD2F30ACF9CFADE2 /* UIImage+TIOCVPixelBufferExtensions.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = "UIImage+TIOCVPixelBufferExtensions.mm"; sourceTree = "<group>"; };
-		295C29DD5D4BAFC55F3136054EB01276 /* TIOModelBundleManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOModelBundleManager.h; sourceTree = "<group>"; };
-		2C30AEEAB1D62EE79285CC68710C89D4 /* TIOVectorLayerDescription.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOVectorLayerDescription.mm; sourceTree = "<group>"; };
 		2C33433F18B04CD1E8FB7CAA8A4ECA60 /* DSJSONSchemaCombiningValidator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSJSONSchemaCombiningValidator.h; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaCombiningValidator.h"; sourceTree = "<group>"; };
 		2C7C371650201D6331306518F09A694B /* DSJSONDictionarySchema.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSJSONDictionarySchema.m; path = DSJSONSchemaValidation/DSJSONDictionarySchema.m; sourceTree = "<group>"; };
 		2C9AC358103F0967D0E30C1CF8AA3062 /* TIOTFLiteModel.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOTFLiteModel.mm; sourceTree = "<group>"; };
+		2F0B02B323F2A9532B3C4A5D9C1FBA2A /* TIOTrainableModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOTrainableModel.h; sourceTree = "<group>"; };
+		2F6AF9ACFC53AAA315F1122E283F2D8F /* TIOBatchDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOBatchDataSource.h; sourceTree = "<group>"; };
 		311871CE9407DCE34C71F887964D8588 /* model-schema.json */ = {isa = PBXFileReference; includeInIndex = 1; name = "model-schema.json"; path = "TensorIO/Assets/TFLite/model-schema.json"; sourceTree = "<group>"; };
-		32DCE98FFB913FE643621CF26E3CF055 /* UIImage+TIOCVPixelBufferExtensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UIImage+TIOCVPixelBufferExtensions.h"; sourceTree = "<group>"; };
-		3361AAC50D280D558D9271B7667B978B /* TIOErrorHandling.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOErrorHandling.h; sourceTree = "<group>"; };
+		326539C23443CB202942A2D33168F3F8 /* TIOVisionPipeline.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOVisionPipeline.h; sourceTree = "<group>"; };
+		345C079CC22E10B62729859666F75556 /* TIOModelIO.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOModelIO.h; sourceTree = "<group>"; };
 		35E4644AD1B9382D548A9B36239F58EF /* TIOPixelBuffer+TIOTFLiteData.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "TIOPixelBuffer+TIOTFLiteData.h"; sourceTree = "<group>"; };
 		36328C15B073A55ACA4C13E746A638F2 /* NSArray+TIOTFLiteData.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = "NSArray+TIOTFLiteData.mm"; sourceTree = "<group>"; };
-		376AC05902DE7A82CEE11DA34E084936 /* TIOModelBundleManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TIOModelBundleManager.m; sourceTree = "<group>"; };
-		37C9BF180B88013E01ECD079259AF88C /* TIOModelJSONParsing.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOModelJSONParsing.mm; sourceTree = "<group>"; };
 		38BEA87055C538ECE505D9A33584F5F1 /* DSJSONSchemaValidation-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "DSJSONSchemaValidation-umbrella.h"; sourceTree = "<group>"; };
-		3B3C5FDE164E2EC70B3B68F74EFBB386 /* TIOInMemoryBatchDataSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TIOInMemoryBatchDataSource.m; sourceTree = "<group>"; };
 		3B40CF226259FCEA93759DE10EAC36D4 /* DSJSONSchemaValidation-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "DSJSONSchemaValidation-dummy.m"; sourceTree = "<group>"; };
+		3D41A0F77B359442BD94598B08BB02E3 /* TIOLayerInterface.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOLayerInterface.h; sourceTree = "<group>"; };
+		3E8584567A6D6603125D133B525DCDF0 /* TIOInMemoryBatchDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOInMemoryBatchDataSource.h; sourceTree = "<group>"; };
 		3E9170713FF4B5798F31BAB3C2C11BAE /* DSJSONSchemaObjectPropertiesValidator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSJSONSchemaObjectPropertiesValidator.h; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaObjectPropertiesValidator.h"; sourceTree = "<group>"; };
-		3F52BCEC91138320B52D4B3A3D970D41 /* TIOBatch.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOBatch.h; sourceTree = "<group>"; };
 		3F80BD75E83F474B0ADB392D53C9115B /* TensorIO.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = TensorIO.framework; path = TensorIO.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		40EFCD590CD6C96F21BC46E1986C686B /* TIOPixelBufferLayerDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOPixelBufferLayerDescription.h; sourceTree = "<group>"; };
+		4036256BF9D6E52293BCCFB20D4C581E /* TIOBatch.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOBatch.h; sourceTree = "<group>"; };
+		404510489D0B67BA126235BD3B02291D /* TIOQuantization.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOQuantization.mm; sourceTree = "<group>"; };
 		4264E268688085CDFCE691D722E63606 /* DSJSONSchemaFormatValidator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSJSONSchemaFormatValidator.h; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaFormatValidator.h"; sourceTree = "<group>"; };
 		43004BF7392D431922F11D5407D9F0F4 /* NSNumber+DSJSONNumberTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSNumber+DSJSONNumberTypes.h"; path = "DSJSONSchemaValidation/Categories/NSNumber+DSJSONNumberTypes.h"; sourceTree = "<group>"; };
 		484F01267E6BD98886214138047D81B3 /* DSJSONSchemaDependenciesValidator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSJSONSchemaDependenciesValidator.h; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaDependenciesValidator.h"; sourceTree = "<group>"; };
-		48E9A7946B912F93F1C727A4E4295647 /* TIOModelBundleJSONSchema.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOModelBundleJSONSchema.h; sourceTree = "<group>"; };
+		488EEAEA100720633633B4AD515BF635 /* TIOVisionModelHelpers.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOVisionModelHelpers.mm; sourceTree = "<group>"; };
+		494D1E8F1E2A3272C1D49E8532152EC2 /* TIOModelBundleManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOModelBundleManager.h; sourceTree = "<group>"; };
 		4A4518A8AD3D7A126D365A5428202BC1 /* DSJSONSchemaValidationOptions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSJSONSchemaValidationOptions.m; path = DSJSONSchemaValidation/DSJSONSchemaValidationOptions.m; sourceTree = "<group>"; };
-		4B498F76A3D666B715CE27D0C488F8DB /* TIOTrainableModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOTrainableModel.h; sourceTree = "<group>"; };
 		4B4E919AEE8A0080C78B312A97CF7C8C /* Pods-TensorIO_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-TensorIO_Example-umbrella.h"; sourceTree = "<group>"; };
-		4F8FBFF34B833A12973761829B09FB4F /* TIOPlaceholderModel.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOPlaceholderModel.mm; sourceTree = "<group>"; };
-		52A3C3041378F88DE997373F11FA97E2 /* TIOVisionModelHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOVisionModelHelpers.h; sourceTree = "<group>"; };
+		51BD662550A0D4E9CCBD1DFF01BF492F /* NSDictionary+TIOExtensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+TIOExtensions.h"; sourceTree = "<group>"; };
 		5337A26EF5E17297138091D477269CDC /* Pods-TensorIO_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-TensorIO_Example-acknowledgements.plist"; sourceTree = "<group>"; };
 		5547FCE18BBE4C8103C69F1C4DD4D242 /* DSJSONSchemaStringValidator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSJSONSchemaStringValidator.h; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaStringValidator.h"; sourceTree = "<group>"; };
 		5556A9FCD3D8394E63321DC3ABAEB41B /* TensorFlowLite.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = TensorFlowLite.xcconfig; sourceTree = "<group>"; };
+		561DDC84C41E47E27621941D243B299F /* TIOVectorLayerDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOVectorLayerDescription.h; sourceTree = "<group>"; };
+		5788DB34CA8C952C124B8B8DFDCDDB41 /* TIOPixelBuffer.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOPixelBuffer.mm; sourceTree = "<group>"; };
 		57BE7D271C6C8F77932E49B5787B71F6 /* NSData+TIOTFLiteData.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSData+TIOTFLiteData.h"; sourceTree = "<group>"; };
 		59A35E46CB7C8EB04FFD35BC9BBF9486 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
 		5A29243DFFBBC028F0A88476183CF15E /* NSData+TIOTFLiteData.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = "NSData+TIOTFLiteData.mm"; sourceTree = "<group>"; };
-		5A310238D9BB50260E75296E0962C2E8 /* TIOModelBackend.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOModelBackend.mm; sourceTree = "<group>"; };
 		5A390F7A0456FCA123FB114E5F9EB71B /* DSJSONSchemaDependenciesValidator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSJSONSchemaDependenciesValidator.m; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaDependenciesValidator.m"; sourceTree = "<group>"; };
-		5C1EE7C7619646CBE79BAD9792FF9BC5 /* NSDictionary+TIOExtensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+TIOExtensions.h"; sourceTree = "<group>"; };
-		5DB77F185C1E64A88B474AD6899CD5A0 /* TIOMeasurable.c */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOMeasurable.c; sourceTree = "<group>"; };
 		5E9A88B990932CA0A94839ECC307A348 /* DSJSONSchemaContentValidator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSJSONSchemaContentValidator.h; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaContentValidator.h"; sourceTree = "<group>"; };
 		5ED4E2B6E87AC185EFB0F19340BE9453 /* DSJSONSchemaValidation-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "DSJSONSchemaValidation-prefix.pch"; sourceTree = "<group>"; };
 		609C362DAA73453B7A8A700F627C01C2 /* DSJSONSchemaArrayItemsValidator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSJSONSchemaArrayItemsValidator.m; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaArrayItemsValidator.m"; sourceTree = "<group>"; };
 		60F96F120BA4B9ED9BB7335390BC6C52 /* DSJSONSchemaObjectValidator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSJSONSchemaObjectValidator.h; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaObjectValidator.h"; sourceTree = "<group>"; };
+		61D8372A527875C76CD947585E988AB8 /* TIOData.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOData.h; sourceTree = "<group>"; };
+		62ABFD920DEF23EBEA334F40ACF021B6 /* TIOPixelNormalization.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOPixelNormalization.mm; sourceTree = "<group>"; };
+		6389DA7E1F0C76355032516E99CABB80 /* TIOModelBackend.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOModelBackend.h; sourceTree = "<group>"; };
 		65CF7E076DFA69E5B4EA77822CC31AC0 /* TensorIO.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = TensorIO.modulemap; sourceTree = "<group>"; };
+		65DF071BD86CCDEC253EFE73A4D49263 /* TIOModelBundleValidator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TIOModelBundleValidator.m; sourceTree = "<group>"; };
 		67E5E8E761B7DBD4FE4204CCD2537D88 /* DSJSONSchemaStorage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSJSONSchemaStorage.m; path = DSJSONSchemaValidation/DSJSONSchemaStorage.m; sourceTree = "<group>"; };
 		6826B463DCA341D9F2338E0CAEEA9687 /* DSJSONSchemaConstValidator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSJSONSchemaConstValidator.m; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaConstValidator.m"; sourceTree = "<group>"; };
-		688312FAD412DEA7235AC8BEFC27123A /* NSArray+TIOExtensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSArray+TIOExtensions.h"; sourceTree = "<group>"; };
+		6E514BA373B228C7A602112F9E5FBB22 /* TIOModelTrainer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TIOModelTrainer.m; sourceTree = "<group>"; };
 		6ECDA26A461255CAFAE8209E84970C5C /* DSJSONSchemaCombiningValidator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSJSONSchemaCombiningValidator.m; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaCombiningValidator.m"; sourceTree = "<group>"; };
 		6EE0F32DA5637643907AC106377FD5E2 /* DSJSONSchemaObjectPropertiesValidator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSJSONSchemaObjectPropertiesValidator.m; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaObjectPropertiesValidator.m"; sourceTree = "<group>"; };
 		6F3ACE2A15977A6F4C8514496F15A0E7 /* DSJSONSchemaDefinitions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSJSONSchemaDefinitions.h; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaDefinitions.h"; sourceTree = "<group>"; };
-		6F681275BD4351CA4D1FABC46DDAA8B1 /* TIOLayerInterface.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOLayerInterface.h; sourceTree = "<group>"; };
 		71B8102B536E73266F80360D4BCDA1E6 /* TensorIO-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "TensorIO-Info.plist"; sourceTree = "<group>"; };
 		737B8E140717225C0ACDB75BF8956F76 /* NSDictionary+TIOTFLiteData.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+TIOTFLiteData.h"; sourceTree = "<group>"; };
 		7405CD71B4A834C8899E5D961343A77E /* DSJSONSchemaSpecification.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSJSONSchemaSpecification.m; path = DSJSONSchemaValidation/DSJSONSchemaSpecification.m; sourceTree = "<group>"; };
-		75298E757529B7BAEB73DA8E8B771CFD /* TIOQuantization.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOQuantization.mm; sourceTree = "<group>"; };
+		7777B0C279F9B1B52ECFC8BE4BA004C9 /* TIOModelIO.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TIOModelIO.m; sourceTree = "<group>"; };
 		79EB36D6FA12771CD26C0489A1AAEA9C /* DSJSONSchemaFactory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSJSONSchemaFactory.h; path = DSJSONSchemaValidation/DSJSONSchemaFactory.h; sourceTree = "<group>"; };
-		7C6A110C61E7EAD73C595CD78F76BAA3 /* TIOVisionPipeline.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOVisionPipeline.mm; sourceTree = "<group>"; };
-		7E4BBE157085BE569926F4CE27BA7D45 /* TIOCVPixelBufferHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOCVPixelBufferHelpers.h; sourceTree = "<group>"; };
-		802D8B32645EC9F1C4C7E8860BD0148C /* TIOModelTrainer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOModelTrainer.h; sourceTree = "<group>"; };
+		7D2876D71DCF6304DDD3B167C72FA47C /* TIOModelOptions.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOModelOptions.mm; sourceTree = "<group>"; };
+		7D62A78D7C8B8C8C399E31A67914FCEF /* TIOPixelBufferLayerDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOPixelBufferLayerDescription.h; sourceTree = "<group>"; };
+		7E64779F0F5063EC47A67D36E8726584 /* TIOLayerDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOLayerDescription.h; sourceTree = "<group>"; };
 		81BBEC1C97A400D0DAA0508B13B7583E /* NSDictionary+DSJSONDeepMutableCopy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSDictionary+DSJSONDeepMutableCopy.m"; path = "DSJSONSchemaValidation/Categories/NSDictionary+DSJSONDeepMutableCopy.m"; sourceTree = "<group>"; };
 		82217187198121495E9DCE6C4580A35E /* DSJSONSchemaContainsValidator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSJSONSchemaContainsValidator.m; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaContainsValidator.m"; sourceTree = "<group>"; };
 		8292CA810E124D501F5C8044173D36BD /* DSJSONSchemaNumericValidator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSJSONSchemaNumericValidator.h; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaNumericValidator.h"; sourceTree = "<group>"; };
 		837886896C99CD5772731632F36F3CD1 /* DSJSONSchemaConditionalValidator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSJSONSchemaConditionalValidator.h; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaConditionalValidator.h"; sourceTree = "<group>"; };
 		83C9D326925212C994474ED505B45981 /* DSJSONSchemaErrors.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSJSONSchemaErrors.m; path = DSJSONSchemaValidation/DSJSONSchemaErrors.m; sourceTree = "<group>"; };
 		8449DA1D1058CAA3CE16CE4D6182878A /* Pods-TensorIO_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-TensorIO_Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		84845BC02C859A1C5EB133C4C18982B2 /* TIOModelOptions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOModelOptions.h; sourceTree = "<group>"; };
 		858080CCEF0FED775CB56DC47DB4871E /* Pods-TensorIO_Tests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-TensorIO_Tests-Info.plist"; sourceTree = "<group>"; };
-		865623008925A319771721C9A7027FF3 /* NSArray+TIOExtensions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSArray+TIOExtensions.m"; sourceTree = "<group>"; };
 		867BF343176E2FF5F09B26F879420649 /* DSJSONSchemaArrayValidator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSJSONSchemaArrayValidator.m; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaArrayValidator.m"; sourceTree = "<group>"; };
 		87AF76BCD9AB7B62CC9A6235443F9F45 /* NSDictionary+DSJSONComparison.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSDictionary+DSJSONComparison.h"; path = "DSJSONSchemaValidation/Categories/NSDictionary+DSJSONComparison.h"; sourceTree = "<group>"; };
-		884A6D98E44249624BBA49B0C7C921AF /* TIOQuantization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOQuantization.h; sourceTree = "<group>"; };
 		8A61BDDBEF8CAF52240A0E0EAD19A4A1 /* TensorIO.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = TensorIO.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		8B0242F34609B94287F4A28E4E2C3ECA /* TIOModelBundleValidator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOModelBundleValidator.h; sourceTree = "<group>"; };
 		8D745382255BB9F2E04559C7D61BE20F /* NSNumber+TIOTFLiteData.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSNumber+TIOTFLiteData.h"; sourceTree = "<group>"; };
 		8D84FFD3109FD0D2B6678F82BC12CD93 /* ResourceBundle-TFLite-TensorIO-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "ResourceBundle-TFLite-TensorIO-Info.plist"; sourceTree = "<group>"; };
 		8F407729B295FDAF7ED82EC1536D5C70 /* DSJSONSchemaContentValidator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSJSONSchemaContentValidator.m; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaContentValidator.m"; sourceTree = "<group>"; };
+		925F922DB4C5C22FDC6309AD087D0117 /* TIODataTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIODataTypes.h; sourceTree = "<group>"; };
+		93111DA57E1A44FD76A3F1DF8F2E2F17 /* TIOVector.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOVector.h; sourceTree = "<group>"; };
 		93BB0B8163528EEBF6CA16E363689629 /* NSString+DSJSONPointer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSString+DSJSONPointer.h"; path = "DSJSONSchemaValidation/Categories/NSString+DSJSONPointer.h"; sourceTree = "<group>"; };
 		9594FE589507ADF9B05A5783B27CF133 /* Pods-TensorIO_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-TensorIO_Tests.release.xcconfig"; sourceTree = "<group>"; };
-		95F03E661AFEACB9705CD90831866707 /* TIOModelBundle.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOModelBundle.mm; sourceTree = "<group>"; };
 		9636F6E581E203C2629FF74C6895ACD0 /* DSJSONSchemaTypeValidator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSJSONSchemaTypeValidator.h; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaTypeValidator.h"; sourceTree = "<group>"; };
 		964FB52F6F83C9D9F7D62A14E3C72002 /* DSJSONSchemaPropertyNamesValidator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSJSONSchemaPropertyNamesValidator.m; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaPropertyNamesValidator.m"; sourceTree = "<group>"; };
-		984774D856B3F93C5782C008E20B631E /* TIOPixelBufferLayerDescription.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOPixelBufferLayerDescription.mm; sourceTree = "<group>"; };
 		994027DD6BD58936B1B636642AED21A9 /* DSJSONSchemaValidationContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSJSONSchemaValidationContext.h; path = DSJSONSchemaValidation/DSJSONSchemaValidationContext.h; sourceTree = "<group>"; };
+		9965529B7F2F9D148615E43E9CC72FA4 /* TIOModelModes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOModelModes.h; sourceTree = "<group>"; };
+		9CE44B70EE141089435FFA35C6245F5E /* UIImage+TIOCVPixelBufferExtensions.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = "UIImage+TIOCVPixelBufferExtensions.mm"; sourceTree = "<group>"; };
 		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		9F2F002881E91C36A26783A8C7092844 /* TIOMeasurable.c */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOMeasurable.c; sourceTree = "<group>"; };
 		A031ABDFAD8F17AEB4761DD4593F3BFC /* DSJSONSchemaErrors.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSJSONSchemaErrors.h; path = DSJSONSchemaValidation/DSJSONSchemaErrors.h; sourceTree = "<group>"; };
 		A08F80B0EC8774B862B4618C102DD8E3 /* Pods-TensorIO_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-TensorIO_Example.release.xcconfig"; sourceTree = "<group>"; };
+		A0F432C6C9E1E484DE72B8D9455DEBB0 /* TIOBatch.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TIOBatch.m; sourceTree = "<group>"; };
 		A442B276C8D7E40F87C8062B254384E3 /* NSURL+DSJSONReferencing.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSURL+DSJSONReferencing.m"; path = "DSJSONSchemaValidation/Categories/NSURL+DSJSONReferencing.m"; sourceTree = "<group>"; };
+		A49DF966D6E9FB08A771ECA84DC96929 /* TIOCVPixelBufferHelpers.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOCVPixelBufferHelpers.mm; sourceTree = "<group>"; };
 		A6B1B2FE3AB45E7156C68F1BC29B804D /* DSJSONSchemaSpecification.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSJSONSchemaSpecification.h; path = DSJSONSchemaValidation/DSJSONSchemaSpecification.h; sourceTree = "<group>"; };
 		A8E202F1582AE22124105176CEFE10C7 /* tensorflow_lite.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = tensorflow_lite.framework; path = Frameworks/tensorflow_lite.framework; sourceTree = "<group>"; };
 		A90E6B56683D59B909669FD729180F15 /* DSJSONSchemaNumericValidator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSJSONSchemaNumericValidator.m; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaNumericValidator.m"; sourceTree = "<group>"; };
-		AA46A1C8FE974DAC38931A536BDB7915 /* TIOModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOModel.h; sourceTree = "<group>"; };
+		A973795713225C533435B1C38B1B4A68 /* TIOErrorHandling.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOErrorHandling.h; sourceTree = "<group>"; };
 		AA66D1E8654F1A338F058DB6002A60AA /* TIOTFLiteData.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOTFLiteData.h; sourceTree = "<group>"; };
 		AB1014347D0A4F88366F1DB4493EC16B /* DSJSONSchemaFactory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSJSONSchemaFactory.m; path = DSJSONSchemaValidation/DSJSONSchemaFactory.m; sourceTree = "<group>"; };
-		ABABE54931EFB2E3B42677136308869B /* TIOModelTrainer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TIOModelTrainer.m; sourceTree = "<group>"; };
 		AC45932608C29BCA59DC2A6BF40E4473 /* DSJSONSchemaDefinitions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSJSONSchemaDefinitions.m; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaDefinitions.m"; sourceTree = "<group>"; };
 		AC766550D4DD7B7DFC8B039FCB01FE91 /* DSJSONSchemaConstValidator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSJSONSchemaConstValidator.h; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaConstValidator.h"; sourceTree = "<group>"; };
 		ACAA862797E37C913ACF382820FDC170 /* NSDictionary+DSJSONDeepMutableCopy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSDictionary+DSJSONDeepMutableCopy.h"; path = "DSJSONSchemaValidation/Categories/NSDictionary+DSJSONDeepMutableCopy.h"; sourceTree = "<group>"; };
-		ACCB05BBD0358B48619DFED40F5526D1 /* TIOModelModes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOModelModes.h; sourceTree = "<group>"; };
+		ACAC2BFDCDB4262D385E0CE747B859DF /* TIOVectorLayerDescription.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOVectorLayerDescription.mm; sourceTree = "<group>"; };
+		AD86CC15CDD02BF263092B111D6EAB84 /* TIOCVPixelBufferHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOCVPixelBufferHelpers.h; sourceTree = "<group>"; };
 		AEE2329DE533E141B58131513AADC954 /* DSJSONSchemaEnumValidator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSJSONSchemaEnumValidator.m; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaEnumValidator.m"; sourceTree = "<group>"; };
+		B1240EC52BC84C904B2A0B2E4A84A25D /* TIOModelBundle.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOModelBundle.h; sourceTree = "<group>"; };
 		B1CC8AC479C0C0E2D99B3EB59841F8E9 /* TIOPixelBuffer+TIOTFLiteData.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = "TIOPixelBuffer+TIOTFLiteData.mm"; sourceTree = "<group>"; };
 		B3628D60FBE9A5639E45308E83923BBA /* Pods-TensorIO_Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-TensorIO_Tests.modulemap"; sourceTree = "<group>"; };
 		B406C7090634AE36E4E354AB1C83282E /* TensorIO.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = TensorIO.xcconfig; sourceTree = "<group>"; };
-		B58C7B1182B04856DE6B08A42E0B0AC7 /* TIOPixelNormalization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOPixelNormalization.h; sourceTree = "<group>"; };
 		B5EBE498695C4F88CF750EEE220DFD66 /* Pods-TensorIO_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-TensorIO_Example-dummy.m"; sourceTree = "<group>"; };
 		B63EFA829E5AB270D9A9DE8521163309 /* DSJSONSchemaTypeValidator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSJSONSchemaTypeValidator.m; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaTypeValidator.m"; sourceTree = "<group>"; };
-		B8494AEA6C62D8A1081811BFEAD7770A /* TIOModelBundleValidator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOModelBundleValidator.h; sourceTree = "<group>"; };
+		B908F26163DA3B5E857002575B73BC24 /* TIOVisionModelHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOVisionModelHelpers.h; sourceTree = "<group>"; };
 		B919D68BFF3361AD1138831E89C9112B /* NSArray+DSJSONComparison.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSArray+DSJSONComparison.m"; path = "DSJSONSchemaValidation/Categories/NSArray+DSJSONComparison.m"; sourceTree = "<group>"; };
 		B98937D521A7CFFF683B050CAB2647EC /* Pods-TensorIO_Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-TensorIO_Tests-dummy.m"; sourceTree = "<group>"; };
-		BA30957630A6E7EDF48F1CA417F35F6B /* TIOPixelBuffer.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOPixelBuffer.mm; sourceTree = "<group>"; };
 		BA552F8AEB5FCF90B479ECBA489589E3 /* TensorIO-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "TensorIO-dummy.m"; sourceTree = "<group>"; };
 		BA8D26E871C50F7E16BCC12BD89B80E5 /* DSJSONSchemaStringValidator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSJSONSchemaStringValidator.m; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaStringValidator.m"; sourceTree = "<group>"; };
 		BD05046F61D05DA6A3E391169AAC24AB /* DSJSONSchema+StandardValidators.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "DSJSONSchema+StandardValidators.h"; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchema+StandardValidators.h"; sourceTree = "<group>"; };
 		BD2D90CEEBD6704AD099CB8167B16E9F /* DSJSONSchemaFormatValidator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSJSONSchemaFormatValidator.m; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaFormatValidator.m"; sourceTree = "<group>"; };
 		BD62F23CD592C2B481CB7155C4B1C814 /* Pods-TensorIO_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-TensorIO_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		BEF9799384BEBB5582D700D18474A223 /* NSObject+DSJSONComparison.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+DSJSONComparison.m"; path = "DSJSONSchemaValidation/Categories/NSObject+DSJSONComparison.m"; sourceTree = "<group>"; };
-		C03139A1F9D3A648975896D205CD5957 /* TIOLayerInterface.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOLayerInterface.mm; sourceTree = "<group>"; };
 		C33AD2EA7F90B5D204CC90270C088DC2 /* DSJSONSchemaValidator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSJSONSchemaValidator.h; path = DSJSONSchemaValidation/DSJSONSchemaValidator.h; sourceTree = "<group>"; };
+		C379F2E8032783409BA3A9480FDBFBB3 /* NSDictionary+TIOExtensions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+TIOExtensions.m"; sourceTree = "<group>"; };
+		C37E528F92992D33BB8415CF0351F5B7 /* TIOLayerInterface.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOLayerInterface.mm; sourceTree = "<group>"; };
 		C70C464B7CE3CA598B44DAFD64BA643C /* DSJSONSchemaConditionalValidator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSJSONSchemaConditionalValidator.m; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaConditionalValidator.m"; sourceTree = "<group>"; };
 		C733C0FCB2756C52C374E50C7D3E5D3F /* NSNumber+DSJSONNumberTypes.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSNumber+DSJSONNumberTypes.m"; path = "DSJSONSchemaValidation/Categories/NSNumber+DSJSONNumberTypes.m"; sourceTree = "<group>"; };
-		C77B8BF799B142E6241A245F043F95A1 /* TIOPixelBuffer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOPixelBuffer.h; sourceTree = "<group>"; };
 		C7B3CEA1AF225B161FC676940C780561 /* DSJSONSchemaValidation-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "DSJSONSchemaValidation-Info.plist"; sourceTree = "<group>"; };
 		C81372956AFFEE5A857744A74B89AA1D /* DSJSONSchemaStorage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSJSONSchemaStorage.h; path = DSJSONSchemaValidation/DSJSONSchemaStorage.h; sourceTree = "<group>"; };
-		C89230C1B6A2D5E4D8759048DC1F8FB0 /* TIODataTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIODataTypes.h; sourceTree = "<group>"; };
 		CB4607EFCA7C5F75397649E792E2AFCB /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		CCD354C71ABD6F3D27E10F5D0A506079 /* DSJSONSchemaReference.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSJSONSchemaReference.h; path = DSJSONSchemaValidation/DSJSONSchemaReference.h; sourceTree = "<group>"; };
+		CE60198C154CFA63D4B7641C923B9600 /* TIOModelBundleJSONSchema.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOModelBundleJSONSchema.h; sourceTree = "<group>"; };
+		CF194A5E8D223961F1C3E254218327C7 /* TIOModelOptions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOModelOptions.h; sourceTree = "<group>"; };
 		CF27E284C6F18582EDAAFC5CFF3197A8 /* TFLite.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = TFLite.bundle; path = "TensorIO-TFLite.bundle"; sourceTree = BUILT_PRODUCTS_DIR; };
-		D0BE675A97CD343800D6B8A07EE16EAF /* TIOModelOptions.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOModelOptions.mm; sourceTree = "<group>"; };
 		D16A280AA243D5B012E723E787F4DE5A /* DSJSONSchema.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSJSONSchema.m; path = DSJSONSchemaValidation/DSJSONSchema.m; sourceTree = "<group>"; };
+		D188D3E48C328C26F5E2E445D21DA357 /* TIOModelBackend.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOModelBackend.mm; sourceTree = "<group>"; };
 		D1D83B87C15F41CC40E019E25B1E8DF5 /* DSJSONSchemaValidation.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = DSJSONSchemaValidation.modulemap; sourceTree = "<group>"; };
 		D230EE889369E4DCB2BDED38D0B290DC /* Pods-TensorIO_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-TensorIO_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
 		D342E3C3E62ADABC73727CD8524D3B58 /* DSJSONSchemaValidation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = DSJSONSchemaValidation.framework; path = DSJSONSchemaValidation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		D3586280FCC045A0DE59A4E1496E9D12 /* TIOModelBundleValidator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TIOModelBundleValidator.m; sourceTree = "<group>"; };
-		D3DE9D7D6E748E82A15D4696F61A6AFA /* TIOLayerDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOLayerDescription.h; sourceTree = "<group>"; };
 		D46C9113371FD702664DED576ED3F0A7 /* TensorIO-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "TensorIO-umbrella.h"; sourceTree = "<group>"; };
 		D5170384645087BBEC50A55D264980AF /* Pods_TensorIO_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_TensorIO_Example.framework; path = "Pods-TensorIO_Example.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		D55CB150FF54A8915332948E39B3DA5E /* TIOModelBundle.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOModelBundle.h; sourceTree = "<group>"; };
+		D52FBF7DD03E71606E6A34F65CFC227B /* TIOPlaceholderModel.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOPlaceholderModel.mm; sourceTree = "<group>"; };
 		D5B17BFEC6A4448A84FFABC8D5EAD3D2 /* Pods-TensorIO_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-TensorIO_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
 		D7E25C93D7C555FCFCAAA46A85927590 /* DSJSONSchema+Protected.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "DSJSONSchema+Protected.h"; path = "DSJSONSchemaValidation/DSJSONSchema+Protected.h"; sourceTree = "<group>"; };
 		D9D51670A79DB90ADDA4A77633168A40 /* DSJSONSchema+StandardValidators.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "DSJSONSchema+StandardValidators.m"; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchema+StandardValidators.m"; sourceTree = "<group>"; };
-		DA7685F6495BFBE071CF6DA6316CC6E9 /* TIOInMemoryBatchDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOInMemoryBatchDataSource.h; sourceTree = "<group>"; };
 		DC6172A0E102C6F3C782CC212D76623C /* DSJSONSchemaValidationContext.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSJSONSchemaValidationContext.m; path = DSJSONSchemaValidation/DSJSONSchemaValidationContext.m; sourceTree = "<group>"; };
 		DC6B5B8D4D36AAE59F15414DF83522E4 /* DSJSONSchemaPropertyNamesValidator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSJSONSchemaPropertyNamesValidator.h; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaPropertyNamesValidator.h"; sourceTree = "<group>"; };
 		DD327A149288BD5D5BACDC2788A725BA /* Pods-TensorIO_Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-TensorIO_Tests-acknowledgements.plist"; sourceTree = "<group>"; };
-		DD4224967C7EB2DC049409086766ECA1 /* TIOModelJSONParsing.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOModelJSONParsing.h; sourceTree = "<group>"; };
 		DD75F743B69E72CD75D399F3B4F23F50 /* NSArray+TIOTFLiteData.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSArray+TIOTFLiteData.h"; sourceTree = "<group>"; };
 		DD89B9C204CC7B040B543653C7E82DBA /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
-		DE4D6998B93870B7EF452A01D27B8EB4 /* TIOVisionPipeline.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOVisionPipeline.h; sourceTree = "<group>"; };
 		DF136A9E9B6673AB8A2DD6085E321A43 /* DSJSONSchemaValidationOptions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSJSONSchemaValidationOptions.h; path = DSJSONSchemaValidation/DSJSONSchemaValidationOptions.h; sourceTree = "<group>"; };
+		DF98D51691CAE05C47FE68A73CD53C9D /* TIOVisionPipeline.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOVisionPipeline.mm; sourceTree = "<group>"; };
 		E315BC33ADFE755B5963DAE1C6119936 /* DSJSONSchemaValidation.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = DSJSONSchemaValidation.xcconfig; sourceTree = "<group>"; };
 		E31DB86FF5A4B976B76423983C1EC416 /* DSJSONSchemaEnumValidator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSJSONSchemaEnumValidator.h; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaEnumValidator.h"; sourceTree = "<group>"; };
+		E32D3694D251A4F13841D0E1496460B5 /* NSArray+TIOExtensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSArray+TIOExtensions.h"; sourceTree = "<group>"; };
 		E51F77FAF20A2DC41DEAFB4CC66C165E /* DSJSONSchemaArrayItemsValidator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSJSONSchemaArrayItemsValidator.h; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaArrayItemsValidator.h"; sourceTree = "<group>"; };
+		E5D8439D42464AA11776E4A0BC8E17F8 /* TIOModelModes.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TIOModelModes.m; sourceTree = "<group>"; };
+		E71D628000D7431A7E3236CF63463403 /* TIOModelJSONParsing.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOModelJSONParsing.mm; sourceTree = "<group>"; };
 		E8DDE30713377D895262B1C4E3897902 /* NSObject+DSJSONComparison.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+DSJSONComparison.h"; path = "DSJSONSchemaValidation/Categories/NSObject+DSJSONComparison.h"; sourceTree = "<group>"; };
+		E94502CA422C9B40941887F209CEC6A6 /* TIOQuantization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOQuantization.h; sourceTree = "<group>"; };
 		E9C6DDD9D4EECCF69FEB67E7F991A274 /* DSJSONSchemaContainsValidator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSJSONSchemaContainsValidator.h; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaContainsValidator.h"; sourceTree = "<group>"; };
 		EA441579012F05E5A91A02F9CB23C556 /* DSJSONSchema.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSJSONSchema.h; path = DSJSONSchemaValidation/DSJSONSchema.h; sourceTree = "<group>"; };
-		EA4718AF6A23D74A35394709D538B437 /* TIOCVPixelBufferHelpers.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOCVPixelBufferHelpers.mm; sourceTree = "<group>"; };
 		EB396A36235F5DD82653BE8706DF0C07 /* Pods-TensorIO_Example-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-TensorIO_Example-Info.plist"; sourceTree = "<group>"; };
-		EF9542A84034CCA72DF9F0CE29DE12F0 /* TIOVector.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOVector.h; sourceTree = "<group>"; };
+		EDC7E5EBD2C346CEAB5EEF20BF7AE346 /* TIOObjcDefer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOObjcDefer.h; sourceTree = "<group>"; };
+		EE5EA34FC299CF65D6C04CA42E9FDBAF /* TIOPixelBuffer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOPixelBuffer.h; sourceTree = "<group>"; };
+		EFC200F970CBC2973C0F302DF8156181 /* TIOModelJSONParsing.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOModelJSONParsing.h; sourceTree = "<group>"; };
 		EFF0640823DC1E3229730544DC2B6688 /* DSJSONSchemaReference.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSJSONSchemaReference.m; path = DSJSONSchemaValidation/DSJSONSchemaReference.m; sourceTree = "<group>"; };
-		F25EBD9F966E191071BD221D8B17F2CF /* TIOModelBackend.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOModelBackend.h; sourceTree = "<group>"; };
+		F15A17521E1FAEC7C3A8171009D18268 /* TIOModelBundle.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOModelBundle.mm; sourceTree = "<group>"; };
+		F29CDD2FFF600831757CF6E9D030EF9D /* TIOMeasurable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOMeasurable.h; sourceTree = "<group>"; };
+		F499745C30AB03F2F6D97C7FBC9AB8FF /* TIOPixelNormalization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TIOPixelNormalization.h; sourceTree = "<group>"; };
 		F8EFA6D531B78F0CCA4B5E3926FEF5D1 /* TIOTFLiteErrors.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = TIOTFLiteErrors.mm; sourceTree = "<group>"; };
-		FB3D4AEFD60948210AA602FB14ECDDE4 /* TIOModelModes.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TIOModelModes.m; sourceTree = "<group>"; };
 		FE37DCC031DE186B342972363690BF29 /* DSJSONSchemaObjectValidator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSJSONSchemaObjectValidator.m; path = "DSJSONSchemaValidation/Standard Validators/DSJSONSchemaObjectValidator.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -475,6 +479,26 @@
 				5332C300ADB4A7BE49D63BA0EAF5E107 /* TIOTFLiteModel */,
 			);
 			name = TFLite;
+			sourceTree = "<group>";
+		};
+		18E21C41B6F76DB32452E11119FE790D /* TIOUtilities */ = {
+			isa = PBXGroup;
+			children = (
+				E32D3694D251A4F13841D0E1496460B5 /* NSArray+TIOExtensions.h */,
+				16E9B17718508E6898D53527153E0C9A /* NSArray+TIOExtensions.m */,
+				51BD662550A0D4E9CCBD1DFF01BF492F /* NSDictionary+TIOExtensions.h */,
+				C379F2E8032783409BA3A9480FDBFBB3 /* NSDictionary+TIOExtensions.m */,
+				AD86CC15CDD02BF263092B111D6EAB84 /* TIOCVPixelBufferHelpers.h */,
+				A49DF966D6E9FB08A771ECA84DC96929 /* TIOCVPixelBufferHelpers.mm */,
+				A973795713225C533435B1C38B1B4A68 /* TIOErrorHandling.h */,
+				9F2F002881E91C36A26783A8C7092844 /* TIOMeasurable.c */,
+				F29CDD2FFF600831757CF6E9D030EF9D /* TIOMeasurable.h */,
+				EDC7E5EBD2C346CEAB5EEF20BF7AE346 /* TIOObjcDefer.h */,
+				00FC5E26402AC13E3BC3059439BFF469 /* UIImage+TIOCVPixelBufferExtensions.h */,
+				9CE44B70EE141089435FFA35C6245F5E /* UIImage+TIOCVPixelBufferExtensions.mm */,
+			);
+			name = TIOUtilities;
+			path = TensorIO/Classes/Core/TIOUtilities;
 			sourceTree = "<group>";
 		};
 		2074F0FBB518100B3417E5F856A62EE7 /* Pods-TensorIO_Example */ = {
@@ -609,49 +633,16 @@
 			path = DSJSONSchemaValidation;
 			sourceTree = "<group>";
 		};
-		3652AD0FC05908F9803A2FFD02F3D691 /* TIOData */ = {
-			isa = PBXGroup;
-			children = (
-				3F52BCEC91138320B52D4B3A3D970D41 /* TIOBatch.h */,
-				02C3623EA36D26C10AFB76087977DAED /* TIOBatch.m */,
-				26461D7555F165F2428A537D659C17E9 /* TIOBatchDataSource.h */,
-				0984B9D1E5550F7E5761B5C84E3A4B73 /* TIOData.h */,
-				DA7685F6495BFBE071CF6DA6316CC6E9 /* TIOInMemoryBatchDataSource.h */,
-				3B3C5FDE164E2EC70B3B68F74EFBB386 /* TIOInMemoryBatchDataSource.m */,
-				C77B8BF799B142E6241A245F043F95A1 /* TIOPixelBuffer.h */,
-				BA30957630A6E7EDF48F1CA417F35F6B /* TIOPixelBuffer.mm */,
-				EF9542A84034CCA72DF9F0CE29DE12F0 /* TIOVector.h */,
-			);
-			name = TIOData;
-			path = TensorIO/Classes/Core/TIOData;
-			sourceTree = "<group>";
-		};
 		4771837790335F3558F0F701E2C4A144 /* TensorIO */ = {
 			isa = PBXGroup;
 			children = (
-				B326E19C00AE85E87E1A74A41F2AB7D3 /* Core */,
+				8D793490D251DDB19F3E563DB67A3474 /* Core */,
 				CF6C235D62FB3DA46005B97D4A64BB1A /* Pod */,
 				A422F8F2D92B62D052EFAB2D440FE469 /* Support Files */,
 				0269317CE3CFD4260DC62E78267BFCAB /* TFLite */,
 			);
 			name = TensorIO;
 			path = ../..;
-			sourceTree = "<group>";
-		};
-		4D607599C7800EEBEB4864D08F739616 /* TIOLayerInterface */ = {
-			isa = PBXGroup;
-			children = (
-				C89230C1B6A2D5E4D8759048DC1F8FB0 /* TIODataTypes.h */,
-				D3DE9D7D6E748E82A15D4696F61A6AFA /* TIOLayerDescription.h */,
-				6F681275BD4351CA4D1FABC46DDAA8B1 /* TIOLayerInterface.h */,
-				C03139A1F9D3A648975896D205CD5957 /* TIOLayerInterface.mm */,
-				40EFCD590CD6C96F21BC46E1986C686B /* TIOPixelBufferLayerDescription.h */,
-				984774D856B3F93C5782C008E20B631E /* TIOPixelBufferLayerDescription.mm */,
-				257ADCDB1753F2C7B4FECF243601BD9F /* TIOVectorLayerDescription.h */,
-				2C30AEEAB1D62EE79285CC68710C89D4 /* TIOVectorLayerDescription.mm */,
-			);
-			name = TIOLayerInterface;
-			path = TensorIO/Classes/Core/TIOLayerInterface;
 			sourceTree = "<group>";
 		};
 		5332C300ADB4A7BE49D63BA0EAF5E107 /* TIOTFLiteModel */ = {
@@ -674,24 +665,43 @@
 			name = "Development Pods";
 			sourceTree = "<group>";
 		};
-		8070C6F7E0ED34C057664B420E692AB2 /* TIOUtilities */ = {
+		68CF2FFCBDC766F858A8BD1283BF1BB5 /* TIOModel */ = {
 			isa = PBXGroup;
 			children = (
-				688312FAD412DEA7235AC8BEFC27123A /* NSArray+TIOExtensions.h */,
-				865623008925A319771721C9A7027FF3 /* NSArray+TIOExtensions.m */,
-				5C1EE7C7619646CBE79BAD9792FF9BC5 /* NSDictionary+TIOExtensions.h */,
-				1E2C145CDEC1A4DA5BDE38BF9330B473 /* NSDictionary+TIOExtensions.m */,
-				7E4BBE157085BE569926F4CE27BA7D45 /* TIOCVPixelBufferHelpers.h */,
-				EA4718AF6A23D74A35394709D538B437 /* TIOCVPixelBufferHelpers.mm */,
-				3361AAC50D280D558D9271B7667B978B /* TIOErrorHandling.h */,
-				5DB77F185C1E64A88B474AD6899CD5A0 /* TIOMeasurable.c */,
-				01C4C1BC2F56AC77B0720DBE3A077290 /* TIOMeasurable.h */,
-				1931AF33B0349CCF76E35260C54A5B65 /* TIOObjcDefer.h */,
-				32DCE98FFB913FE643621CF26E3CF055 /* UIImage+TIOCVPixelBufferExtensions.h */,
-				2931B27637B78357AD2F30ACF9CFADE2 /* UIImage+TIOCVPixelBufferExtensions.mm */,
+				0893DF6CB8C0B3252EEB56B27FDA90BC /* TIOModel.h */,
+				6389DA7E1F0C76355032516E99CABB80 /* TIOModelBackend.h */,
+				D188D3E48C328C26F5E2E445D21DA357 /* TIOModelBackend.mm */,
+				B1240EC52BC84C904B2A0B2E4A84A25D /* TIOModelBundle.h */,
+				F15A17521E1FAEC7C3A8171009D18268 /* TIOModelBundle.mm */,
+				CE60198C154CFA63D4B7641C923B9600 /* TIOModelBundleJSONSchema.h */,
+				494D1E8F1E2A3272C1D49E8532152EC2 /* TIOModelBundleManager.h */,
+				15448BF97A28DBF69DFC514576A15174 /* TIOModelBundleManager.m */,
+				8B0242F34609B94287F4A28E4E2C3ECA /* TIOModelBundleValidator.h */,
+				65DF071BD86CCDEC253EFE73A4D49263 /* TIOModelBundleValidator.m */,
+				345C079CC22E10B62729859666F75556 /* TIOModelIO.h */,
+				7777B0C279F9B1B52ECFC8BE4BA004C9 /* TIOModelIO.m */,
+				EFC200F970CBC2973C0F302DF8156181 /* TIOModelJSONParsing.h */,
+				E71D628000D7431A7E3236CF63463403 /* TIOModelJSONParsing.mm */,
+				9965529B7F2F9D148615E43E9CC72FA4 /* TIOModelModes.h */,
+				E5D8439D42464AA11776E4A0BC8E17F8 /* TIOModelModes.m */,
+				CF194A5E8D223961F1C3E254218327C7 /* TIOModelOptions.h */,
+				7D2876D71DCF6304DDD3B167C72FA47C /* TIOModelOptions.mm */,
+				21FF5B0671044E40CE8827A2D02C52C8 /* TIOModelTrainer.h */,
+				6E514BA373B228C7A602112F9E5FBB22 /* TIOModelTrainer.m */,
+				F499745C30AB03F2F6D97C7FBC9AB8FF /* TIOPixelNormalization.h */,
+				62ABFD920DEF23EBEA334F40ACF021B6 /* TIOPixelNormalization.mm */,
+				171E4F6567BBD1751DCCC76E401CB857 /* TIOPlaceholderModel.h */,
+				D52FBF7DD03E71606E6A34F65CFC227B /* TIOPlaceholderModel.mm */,
+				E94502CA422C9B40941887F209CEC6A6 /* TIOQuantization.h */,
+				404510489D0B67BA126235BD3B02291D /* TIOQuantization.mm */,
+				2F0B02B323F2A9532B3C4A5D9C1FBA2A /* TIOTrainableModel.h */,
+				B908F26163DA3B5E857002575B73BC24 /* TIOVisionModelHelpers.h */,
+				488EEAEA100720633633B4AD515BF635 /* TIOVisionModelHelpers.mm */,
+				326539C23443CB202942A2D33168F3F8 /* TIOVisionPipeline.h */,
+				DF98D51691CAE05C47FE68A73CD53C9D /* TIOVisionPipeline.mm */,
 			);
-			name = TIOUtilities;
-			path = TensorIO/Classes/Core/TIOUtilities;
+			name = TIOModel;
+			path = TensorIO/Classes/Core/TIOModel;
 			sourceTree = "<group>";
 		};
 		865E900F0269B02B4D17B2AEF15776C3 /* Pods */ = {
@@ -703,41 +713,15 @@
 			name = Pods;
 			sourceTree = "<group>";
 		};
-		8A6D7FB32795F6AF060904C67C735596 /* TIOModel */ = {
+		8D793490D251DDB19F3E563DB67A3474 /* Core */ = {
 			isa = PBXGroup;
 			children = (
-				AA46A1C8FE974DAC38931A536BDB7915 /* TIOModel.h */,
-				F25EBD9F966E191071BD221D8B17F2CF /* TIOModelBackend.h */,
-				5A310238D9BB50260E75296E0962C2E8 /* TIOModelBackend.mm */,
-				D55CB150FF54A8915332948E39B3DA5E /* TIOModelBundle.h */,
-				95F03E661AFEACB9705CD90831866707 /* TIOModelBundle.mm */,
-				48E9A7946B912F93F1C727A4E4295647 /* TIOModelBundleJSONSchema.h */,
-				295C29DD5D4BAFC55F3136054EB01276 /* TIOModelBundleManager.h */,
-				376AC05902DE7A82CEE11DA34E084936 /* TIOModelBundleManager.m */,
-				B8494AEA6C62D8A1081811BFEAD7770A /* TIOModelBundleValidator.h */,
-				D3586280FCC045A0DE59A4E1496E9D12 /* TIOModelBundleValidator.m */,
-				DD4224967C7EB2DC049409086766ECA1 /* TIOModelJSONParsing.h */,
-				37C9BF180B88013E01ECD079259AF88C /* TIOModelJSONParsing.mm */,
-				ACCB05BBD0358B48619DFED40F5526D1 /* TIOModelModes.h */,
-				FB3D4AEFD60948210AA602FB14ECDDE4 /* TIOModelModes.m */,
-				84845BC02C859A1C5EB133C4C18982B2 /* TIOModelOptions.h */,
-				D0BE675A97CD343800D6B8A07EE16EAF /* TIOModelOptions.mm */,
-				802D8B32645EC9F1C4C7E8860BD0148C /* TIOModelTrainer.h */,
-				ABABE54931EFB2E3B42677136308869B /* TIOModelTrainer.m */,
-				B58C7B1182B04856DE6B08A42E0B0AC7 /* TIOPixelNormalization.h */,
-				248F28EEE048AF8D1A6118FB2DAFA1FE /* TIOPixelNormalization.mm */,
-				08232AC91EBA18DE368420CBDBB9ED07 /* TIOPlaceholderModel.h */,
-				4F8FBFF34B833A12973761829B09FB4F /* TIOPlaceholderModel.mm */,
-				884A6D98E44249624BBA49B0C7C921AF /* TIOQuantization.h */,
-				75298E757529B7BAEB73DA8E8B771CFD /* TIOQuantization.mm */,
-				4B498F76A3D666B715CE27D0C488F8DB /* TIOTrainableModel.h */,
-				52A3C3041378F88DE997373F11FA97E2 /* TIOVisionModelHelpers.h */,
-				26FC5C143CC91A1EF49381538F33C2E4 /* TIOVisionModelHelpers.mm */,
-				DE4D6998B93870B7EF452A01D27B8EB4 /* TIOVisionPipeline.h */,
-				7C6A110C61E7EAD73C595CD78F76BAA3 /* TIOVisionPipeline.mm */,
+				BAFAE8B3E45BFD166C1DFACBAC54B2B3 /* TIOData */,
+				C8F98A7574E092945FC925C204BE6C5C /* TIOLayerInterface */,
+				68CF2FFCBDC766F858A8BD1283BF1BB5 /* TIOModel */,
+				18E21C41B6F76DB32452E11119FE790D /* TIOUtilities */,
 			);
-			name = TIOModel;
-			path = TensorIO/Classes/Core/TIOModel;
+			name = Core;
 			sourceTree = "<group>";
 		};
 		8EA1CDF473FFB03C330D0971277D0B4B /* Frameworks */ = {
@@ -811,15 +795,37 @@
 			name = "Targets Support Files";
 			sourceTree = "<group>";
 		};
-		B326E19C00AE85E87E1A74A41F2AB7D3 /* Core */ = {
+		BAFAE8B3E45BFD166C1DFACBAC54B2B3 /* TIOData */ = {
 			isa = PBXGroup;
 			children = (
-				3652AD0FC05908F9803A2FFD02F3D691 /* TIOData */,
-				4D607599C7800EEBEB4864D08F739616 /* TIOLayerInterface */,
-				8A6D7FB32795F6AF060904C67C735596 /* TIOModel */,
-				8070C6F7E0ED34C057664B420E692AB2 /* TIOUtilities */,
+				4036256BF9D6E52293BCCFB20D4C581E /* TIOBatch.h */,
+				A0F432C6C9E1E484DE72B8D9455DEBB0 /* TIOBatch.m */,
+				2F6AF9ACFC53AAA315F1122E283F2D8F /* TIOBatchDataSource.h */,
+				61D8372A527875C76CD947585E988AB8 /* TIOData.h */,
+				3E8584567A6D6603125D133B525DCDF0 /* TIOInMemoryBatchDataSource.h */,
+				1CF7CBF12AC537EBB56EB16720A75504 /* TIOInMemoryBatchDataSource.m */,
+				EE5EA34FC299CF65D6C04CA42E9FDBAF /* TIOPixelBuffer.h */,
+				5788DB34CA8C952C124B8B8DFDCDDB41 /* TIOPixelBuffer.mm */,
+				93111DA57E1A44FD76A3F1DF8F2E2F17 /* TIOVector.h */,
 			);
-			name = Core;
+			name = TIOData;
+			path = TensorIO/Classes/Core/TIOData;
+			sourceTree = "<group>";
+		};
+		C8F98A7574E092945FC925C204BE6C5C /* TIOLayerInterface */ = {
+			isa = PBXGroup;
+			children = (
+				925F922DB4C5C22FDC6309AD087D0117 /* TIODataTypes.h */,
+				7E64779F0F5063EC47A67D36E8726584 /* TIOLayerDescription.h */,
+				3D41A0F77B359442BD94598B08BB02E3 /* TIOLayerInterface.h */,
+				C37E528F92992D33BB8415CF0351F5B7 /* TIOLayerInterface.mm */,
+				7D62A78D7C8B8C8C399E31A67914FCEF /* TIOPixelBufferLayerDescription.h */,
+				21FBE58E706F386F77EF167DC2410AF4 /* TIOPixelBufferLayerDescription.mm */,
+				561DDC84C41E47E27621941D243B299F /* TIOVectorLayerDescription.h */,
+				ACAC2BFDCDB4262D385E0CE747B859DF /* TIOVectorLayerDescription.mm */,
+			);
+			name = TIOLayerInterface;
+			path = TensorIO/Classes/Core/TIOLayerInterface;
 			sourceTree = "<group>";
 		};
 		CF1408CF629C7361332E53B88F7BD30C = {
@@ -879,56 +885,6 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		4199807C9D36A881FB699B27EA236B46 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				E51F171A33E6149E98E0AD25DCBCFAEA /* NSArray+TIOExtensions.h in Headers */,
-				C9ABD37ED09D9691509C9F3931D70EFA /* NSArray+TIOTFLiteData.h in Headers */,
-				55BF72D827AAA0FC7DA35C99A7DB1284 /* NSData+TIOTFLiteData.h in Headers */,
-				9805AB007FC2DFF572023A31DD5B82E1 /* NSDictionary+TIOExtensions.h in Headers */,
-				8A6B9056863C63B6DE98FCF282D4C44A /* NSDictionary+TIOTFLiteData.h in Headers */,
-				F6973BE2C4626EF3B9BB6235EA332A29 /* NSNumber+TIOTFLiteData.h in Headers */,
-				905695CE49758A9D2A291C8EEB33CCD6 /* TensorIO-umbrella.h in Headers */,
-				A24827388EC4CB7FE0377EB53A75B106 /* TIOBatch.h in Headers */,
-				80020ADFE108CD8AA00EAA593AC984ED /* TIOBatchDataSource.h in Headers */,
-				2FCB3FB4E37DAD078886C6A24C5480E1 /* TIOCVPixelBufferHelpers.h in Headers */,
-				B203B236EB0DCEDDFE8565CA05CBD481 /* TIOData.h in Headers */,
-				FA70E36853AE08663573D66191446590 /* TIODataTypes.h in Headers */,
-				90CE6425CFF7400A3E2640C58C96E27B /* TIOErrorHandling.h in Headers */,
-				14460796BAEA6CCADC0316170D067BA5 /* TIOInMemoryBatchDataSource.h in Headers */,
-				E6BFDD05276A525CF0F88B87F174C62F /* TIOLayerDescription.h in Headers */,
-				913E2ADD87FDFCB8A3C32F3A191E8473 /* TIOLayerInterface.h in Headers */,
-				8BB2590B2BA4063DACA653DDF2D5E4CC /* TIOMeasurable.h in Headers */,
-				B77D54375427D62C1F1D1CBDEEE12947 /* TIOModel.h in Headers */,
-				573D79D266DE8EBB32BF4E6F9C3E12BA /* TIOModelBackend.h in Headers */,
-				72B936A503C64738EED76435A275945B /* TIOModelBundle.h in Headers */,
-				4764D12BCB3DE963211D144C9AA55F6D /* TIOModelBundleJSONSchema.h in Headers */,
-				C0E2AA05BFBCB58E9E14CE6AA8C3EDA6 /* TIOModelBundleManager.h in Headers */,
-				C3579A8DA3C2BF82F86260A2C61C7DEF /* TIOModelBundleValidator.h in Headers */,
-				6979944AFA896BD6ADACB5650D53F0E4 /* TIOModelJSONParsing.h in Headers */,
-				076437423BD7E95B9EC79BB04A0011F0 /* TIOModelModes.h in Headers */,
-				1C510FEBB471027435F06E94A9D73B99 /* TIOModelOptions.h in Headers */,
-				B0A08DB6038ADD243611FB8C55CEC397 /* TIOModelTrainer.h in Headers */,
-				844B2CDE92FB351BFD4235AEEE7987A4 /* TIOObjcDefer.h in Headers */,
-				4AA8668196B01C0C5EB1E3B624086A1B /* TIOPixelBuffer+TIOTFLiteData.h in Headers */,
-				91A425D3D819E3A93621203602A62B6F /* TIOPixelBuffer.h in Headers */,
-				1E5C484CCBAD6ACB50271667E6853200 /* TIOPixelBufferLayerDescription.h in Headers */,
-				E3C05EB7DD1AF14693EB8168DE55B3CD /* TIOPixelNormalization.h in Headers */,
-				053B3BE4AF56D86A947D30B2E75A7874 /* TIOPlaceholderModel.h in Headers */,
-				F6CC65C1FC79A8AD9C484C60162DD652 /* TIOQuantization.h in Headers */,
-				7066118FAD3985303E2AF073C63BE328 /* TIOTFLiteData.h in Headers */,
-				380A886AA55C2F59A61CE4E50B843C54 /* TIOTFLiteErrors.h in Headers */,
-				3B4F44B8E4A9F0BC3E86C8D17905AAB8 /* TIOTFLiteModel.h in Headers */,
-				7DCB0961C26B49B06355AF84EF4D1BEA /* TIOTrainableModel.h in Headers */,
-				DA724C89488D77BDFFDC58AA3E7D0A1E /* TIOVector.h in Headers */,
-				1AB33B8DC84351DF28995A69419629B1 /* TIOVectorLayerDescription.h in Headers */,
-				D33FA0A917E565C879B3352FDB1C1C91 /* TIOVisionModelHelpers.h in Headers */,
-				03460A08D4B8F948725438A513A89C09 /* TIOVisionPipeline.h in Headers */,
-				EDF728A38FC31708ABE6E8EF96CA5A95 /* UIImage+TIOCVPixelBufferExtensions.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		6B12CC6243132615609F0D6594532765 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -990,6 +946,57 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		ED831520B896484642B49D9E8D12E7FF /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E9FD59C64730F7DABB578BE46E5CB4A5 /* NSArray+TIOExtensions.h in Headers */,
+				60C943C09E0A04434E9D7F4618F476AC /* NSArray+TIOTFLiteData.h in Headers */,
+				8D990980F4B21806789702FBF2ED2E36 /* NSData+TIOTFLiteData.h in Headers */,
+				241914046E99233A16D8B3EF7ADACD8B /* NSDictionary+TIOExtensions.h in Headers */,
+				4BA9B13832E158B04280D3A2613A46DE /* NSDictionary+TIOTFLiteData.h in Headers */,
+				0FFF86381236C826672265099E97C3C0 /* NSNumber+TIOTFLiteData.h in Headers */,
+				5E34E47A153B47F19888D145262BEEE3 /* TensorIO-umbrella.h in Headers */,
+				87D28054F6854BDE3B2DE67DCC77A57F /* TIOBatch.h in Headers */,
+				526FAF86B22BF492DC46947F254510CC /* TIOBatchDataSource.h in Headers */,
+				425D9851D0BD30EE44548D5EA8A66BC4 /* TIOCVPixelBufferHelpers.h in Headers */,
+				4C301768A4CD17053F3D878C93E00571 /* TIOData.h in Headers */,
+				6B667FA32FCE07F82A0BF0158E7C5649 /* TIODataTypes.h in Headers */,
+				B1267ABBE38506CC819EF1DDFC53ED66 /* TIOErrorHandling.h in Headers */,
+				A1B23108EE0FF78D0BEE59655EC7A0CA /* TIOInMemoryBatchDataSource.h in Headers */,
+				2AA2DD9BA06099C41315A6DAB5DDC654 /* TIOLayerDescription.h in Headers */,
+				93D80604D25857B1B86F8ACFB5867138 /* TIOLayerInterface.h in Headers */,
+				9DD9DBB530EA0A60C6F2EC30C0406231 /* TIOMeasurable.h in Headers */,
+				B338A915AD0ED1E16B9EDBB1EF75A40C /* TIOModel.h in Headers */,
+				9DFF114B96C22E7F6D198E443EB3750E /* TIOModelBackend.h in Headers */,
+				78C6E1686B5DAA385233A1492145B926 /* TIOModelBundle.h in Headers */,
+				5DDF934B52E1449027EBC2FBB6BC9915 /* TIOModelBundleJSONSchema.h in Headers */,
+				F3DCF6BDEB41C24E88E8D10AACC8978D /* TIOModelBundleManager.h in Headers */,
+				818D54192A27B45DD06C3E726EAC7FA7 /* TIOModelBundleValidator.h in Headers */,
+				4F15783C3F88F315FDE5467411165652 /* TIOModelIO.h in Headers */,
+				7586A375C9D7078848F93A4AB55E5B07 /* TIOModelJSONParsing.h in Headers */,
+				2151805A5A92461511C13E0699DF8775 /* TIOModelModes.h in Headers */,
+				EF5EA65ADDFC993D9CBD8317BDC42EE2 /* TIOModelOptions.h in Headers */,
+				CEAFF2AA9B0485A361F2AC80A24001B7 /* TIOModelTrainer.h in Headers */,
+				C19310364041505463AE4BC89F1969AF /* TIOObjcDefer.h in Headers */,
+				60DC8C0B09F9F5196273E1B79997A4D7 /* TIOPixelBuffer+TIOTFLiteData.h in Headers */,
+				8B6FD08E02035857107D4E0B7016242C /* TIOPixelBuffer.h in Headers */,
+				48653D0AD057C12CD6296EBD423DB1F6 /* TIOPixelBufferLayerDescription.h in Headers */,
+				61D2E18EE2A3E905622F8509E298E15F /* TIOPixelNormalization.h in Headers */,
+				11CA54688EF51A386632D9B30EBC2AAF /* TIOPlaceholderModel.h in Headers */,
+				FC3F7D411144DF195C045113647FC7EE /* TIOQuantization.h in Headers */,
+				95BC48719546776E014C9D3BC6EA8BEA /* TIOTFLiteData.h in Headers */,
+				AA81AB90CB4BC89B60516E96A44BAEA7 /* TIOTFLiteErrors.h in Headers */,
+				99BE15A50E56DDA54E93E1723F509E04 /* TIOTFLiteModel.h in Headers */,
+				67A67D40EB5075656E1BEBBA9B39D98A /* TIOTrainableModel.h in Headers */,
+				19A38997B40A1A0F6F02599BA4811F26 /* TIOVector.h in Headers */,
+				2E9B3A94FE269B992120AE65E812F588 /* TIOVectorLayerDescription.h in Headers */,
+				79F4F4539C2EAB9A38FCBD1179C9DC41 /* TIOVisionModelHelpers.h in Headers */,
+				E6D71B7A8810A3C9781832E32586715A /* TIOVisionPipeline.h in Headers */,
+				32CF69418021FDF1A5320AFD104D4A97 /* UIImage+TIOCVPixelBufferExtensions.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
@@ -1018,8 +1025,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = BF5AD0E98A7BBF80AE59B4BC3386BC87 /* Build configuration list for PBXNativeTarget "TensorIO" */;
 			buildPhases = (
-				4199807C9D36A881FB699B27EA236B46 /* Headers */,
-				BE33D6EC51E2AA5A446A9087938296A6 /* Sources */,
+				ED831520B896484642B49D9E8D12E7FF /* Headers */,
+				C562BEFB5C35DFF641CE4AEC19FB2150 /* Sources */,
 				C18B213DCDCC9304AEF6F5644D0AE5C6 /* Frameworks */,
 				1599310C5F8B1A3FCEDDC875C22D42B7 /* Resources */,
 			);
@@ -1227,42 +1234,43 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		BE33D6EC51E2AA5A446A9087938296A6 /* Sources */ = {
+		C562BEFB5C35DFF641CE4AEC19FB2150 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6BECE195777FD82193944F3E7600840B /* NSArray+TIOExtensions.m in Sources */,
-				7B9AF99336EC62D592F127308691409A /* NSArray+TIOTFLiteData.mm in Sources */,
-				4FCEABB32E4C94EE15C6BB99EA26F378 /* NSData+TIOTFLiteData.mm in Sources */,
-				1D2BF4D383AF38FCBF5D621B2FE22101 /* NSDictionary+TIOExtensions.m in Sources */,
-				8C4979148611CF015104F71D7FF6082B /* NSDictionary+TIOTFLiteData.mm in Sources */,
-				4F02DEF5B11711163383AB588ACD62D3 /* NSNumber+TIOTFLiteData.mm in Sources */,
-				25CC22E35223D530FD29E2317218AE1F /* TensorIO-dummy.m in Sources */,
-				FBE2B5F3B899FF743E5E999644F676B8 /* TIOBatch.m in Sources */,
-				83AD74EB3376A4E20783FB18133DEEC6 /* TIOCVPixelBufferHelpers.mm in Sources */,
-				7A765DE61DBCF4FE6DDFB50DC21575D8 /* TIOInMemoryBatchDataSource.m in Sources */,
-				BE830E010A1587170EDE029D362ABF08 /* TIOLayerInterface.mm in Sources */,
-				5BB1A62C7890AA3333C5C2C1B46BCE65 /* TIOMeasurable.c in Sources */,
-				780E1AFA86E13CFA9EA52B700832BE37 /* TIOModelBackend.mm in Sources */,
-				38643ABB91E59A6CCBA72CCBE2E8D041 /* TIOModelBundle.mm in Sources */,
-				FEE1B509BB0265286DACC11B2FBE8FF1 /* TIOModelBundleManager.m in Sources */,
-				5A543E503D8A8E82A6407C3740B71A25 /* TIOModelBundleValidator.m in Sources */,
-				5711EB3EC41E50FB4B095A91F5D89E61 /* TIOModelJSONParsing.mm in Sources */,
-				9265C00A66731C621E0AB37948411B62 /* TIOModelModes.m in Sources */,
-				E86D3C07766F32FB9B3D5B7463AE1B57 /* TIOModelOptions.mm in Sources */,
-				3BC3F9A799674C4BC154502C9AC9A6C8 /* TIOModelTrainer.m in Sources */,
-				B2CDEF648454CF28D1858E53FC47F17E /* TIOPixelBuffer+TIOTFLiteData.mm in Sources */,
-				2A8F9BAC38E5CD12D7F09CA73625BD0C /* TIOPixelBuffer.mm in Sources */,
-				61B685CEDBBE2A41D289FB4D0160644B /* TIOPixelBufferLayerDescription.mm in Sources */,
-				80DE86579E9EC5706B2CC015B7967896 /* TIOPixelNormalization.mm in Sources */,
-				505CC0F72EA91C2EE6A876D65AA9F841 /* TIOPlaceholderModel.mm in Sources */,
-				19801A649693C1BDA189058A8B303044 /* TIOQuantization.mm in Sources */,
-				9A25BC69CC2E1283D3C759363D4141F1 /* TIOTFLiteErrors.mm in Sources */,
-				6006792AAAD574F496EAE66528A6DFEA /* TIOTFLiteModel.mm in Sources */,
-				30CDD84FCD484C37B6656245DCE92B00 /* TIOVectorLayerDescription.mm in Sources */,
-				FECBFE4171B5FF2D2425225788BBCB74 /* TIOVisionModelHelpers.mm in Sources */,
-				FC97000D18AE7F5DD58941ED46B8A004 /* TIOVisionPipeline.mm in Sources */,
-				26743750ACFCC5B94951723EE6AEE906 /* UIImage+TIOCVPixelBufferExtensions.mm in Sources */,
+				CC6BA2A5F92949D73DE2BBC6E45C484E /* NSArray+TIOExtensions.m in Sources */,
+				FA57519584BEF5C0CC7C22EA90A8215F /* NSArray+TIOTFLiteData.mm in Sources */,
+				F328EF7C28404D9C6C9B9E9ECB19D13A /* NSData+TIOTFLiteData.mm in Sources */,
+				75CC80474BDAD4CD0F35579B7CEB87F3 /* NSDictionary+TIOExtensions.m in Sources */,
+				849D7B731446CABF2C7A9AC9878828DE /* NSDictionary+TIOTFLiteData.mm in Sources */,
+				4B30B53BED2D28633DE73182C48A0C59 /* NSNumber+TIOTFLiteData.mm in Sources */,
+				253703A23C5269DD770F90C24AF5671B /* TensorIO-dummy.m in Sources */,
+				4AB5367D9478AD0508A0396DCB89E30E /* TIOBatch.m in Sources */,
+				FE53FCE64D1F18E866DC0C4A9EE15707 /* TIOCVPixelBufferHelpers.mm in Sources */,
+				4CCEEF119ED4138C240CE003D295C9E1 /* TIOInMemoryBatchDataSource.m in Sources */,
+				4C2C46C57F3AB7432FEA55FF17D338E9 /* TIOLayerInterface.mm in Sources */,
+				E2DA0499B4E4D8BF8D9FD5E74F6781B2 /* TIOMeasurable.c in Sources */,
+				09C1691387A0F23E32AC8BBC817DBA5E /* TIOModelBackend.mm in Sources */,
+				E559523E48CC0F9BB17427CD5ADCF9A3 /* TIOModelBundle.mm in Sources */,
+				3211A43E4FBDF51EC8FE6986AC0C2DF8 /* TIOModelBundleManager.m in Sources */,
+				3A9DAD920B22EBD389E39D278698317E /* TIOModelBundleValidator.m in Sources */,
+				CA82030686A576943FD91E34B0FB1F87 /* TIOModelIO.m in Sources */,
+				A95A241242C43E0D67ABD7EC364A11A8 /* TIOModelJSONParsing.mm in Sources */,
+				E150719832F8301A438281890EF1D9F1 /* TIOModelModes.m in Sources */,
+				52E123DAEF6A0369B90899D2F2C38949 /* TIOModelOptions.mm in Sources */,
+				06AC87143DE611249A804C8F068495EF /* TIOModelTrainer.m in Sources */,
+				042E5A2170436CD3003AED8B48CD8BD8 /* TIOPixelBuffer+TIOTFLiteData.mm in Sources */,
+				FC4C32B107718880B4664B2B698EE5F8 /* TIOPixelBuffer.mm in Sources */,
+				8C535D74329E0BC7EFA1B92D99904C66 /* TIOPixelBufferLayerDescription.mm in Sources */,
+				619F9B032CA3B51B2E7476E3AD3522C8 /* TIOPixelNormalization.mm in Sources */,
+				89F6106C3EF93F00F1B79E89F80AD097 /* TIOPlaceholderModel.mm in Sources */,
+				9C0907B867CEA55A96A9CBE2EA07A21B /* TIOQuantization.mm in Sources */,
+				9BB9B978BBD4A7BB0552D94F1ACF83A3 /* TIOTFLiteErrors.mm in Sources */,
+				530A62A3E3EB8CEFFEE27D0CFE873B8A /* TIOTFLiteModel.mm in Sources */,
+				0EFBE840B566D8FD6D15B7518B05F0DA /* TIOVectorLayerDescription.mm in Sources */,
+				1C38EFF5F247EF221609A6C5A33FD77F /* TIOVisionModelHelpers.mm in Sources */,
+				2799C2CEB29159DB1881F9DA3638E4EF /* TIOVisionPipeline.mm in Sources */,
+				228042E2869B9A92AB22DDDCE781B98C /* UIImage+TIOCVPixelBufferExtensions.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/Pods/Target Support Files/TensorIO/TensorIO-umbrella.h
+++ b/Example/Pods/Target Support Files/TensorIO/TensorIO-umbrella.h
@@ -27,6 +27,7 @@
 #import "TIOModelBundleJSONSchema.h"
 #import "TIOModelBundleManager.h"
 #import "TIOModelBundleValidator.h"
+#import "TIOModelIO.h"
 #import "TIOModelJSONParsing.h"
 #import "TIOModelModes.h"
 #import "TIOModelOptions.h"

--- a/Example/TensorIO.xcodeproj/project.pbxproj
+++ b/Example/TensorIO.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		E34F12D32278CA4F000A0DD7 /* TIOModelModesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E34F12D22278CA4F000A0DD7 /* TIOModelModesTests.m */; };
 		E3B1AD0E214ADE7E0094E065 /* TensorIOModelBundleValidatorTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E3B1AD0D214ADE7E0094E065 /* TensorIOModelBundleValidatorTests.mm */; };
 		E3B2A902227226C20080DFDD /* TIOBatchTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E3B2A901227226C20080DFDD /* TIOBatchTests.m */; };
+		E3DB3E0222C3EE51009D525D /* TIOModelIOTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E3DB3E0122C3EE51009D525D /* TIOModelIOTests.m */; };
 		E3E16DD0229321D00087197A /* TIOMockTrainableModel.m in Sources */ = {isa = PBXBuildFile; fileRef = E3E16DCE229321D00087197A /* TIOMockTrainableModel.m */; };
 		E3E16DD2229321D90087197A /* TIOModelTrainerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E3E16DD1229321D90087197A /* TIOModelTrainerTests.m */; };
 		E3E16DD7229322640087197A /* TIOMockBatchDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = E3E16DD6229322640087197A /* TIOMockBatchDataSource.m */; };
@@ -97,6 +98,7 @@
 		E34F12D22278CA4F000A0DD7 /* TIOModelModesTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TIOModelModesTests.m; sourceTree = "<group>"; };
 		E3B1AD0D214ADE7E0094E065 /* TensorIOModelBundleValidatorTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TensorIOModelBundleValidatorTests.mm; sourceTree = "<group>"; };
 		E3B2A901227226C20080DFDD /* TIOBatchTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TIOBatchTests.m; sourceTree = "<group>"; };
+		E3DB3E0122C3EE51009D525D /* TIOModelIOTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TIOModelIOTests.m; sourceTree = "<group>"; };
 		E3E16DCE229321D00087197A /* TIOMockTrainableModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TIOMockTrainableModel.m; sourceTree = "<group>"; };
 		E3E16DCF229321D00087197A /* TIOMockTrainableModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TIOMockTrainableModel.h; sourceTree = "<group>"; };
 		E3E16DD1229321D90087197A /* TIOModelTrainerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TIOModelTrainerTests.m; sourceTree = "<group>"; };
@@ -217,6 +219,7 @@
 				E3B2A901227226C20080DFDD /* TIOBatchTests.m */,
 				E3E16DD1229321D90087197A /* TIOModelTrainerTests.m */,
 				E3E16DD82293231D0087197A /* TIOInMemoryBatchDataSourceTests.m */,
+				E3DB3E0122C3EE51009D525D /* TIOModelIOTests.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -464,6 +467,7 @@
 				E3B2A902227226C20080DFDD /* TIOBatchTests.m in Sources */,
 				E3B1AD0E214ADE7E0094E065 /* TensorIOModelBundleValidatorTests.mm in Sources */,
 				E31C79DF212F63AC00139C90 /* TensorIODataTests.mm in Sources */,
+				E3DB3E0222C3EE51009D525D /* TIOModelIOTests.m in Sources */,
 				E3197F752268F57F0082047D /* TIOModelBackendTests.mm in Sources */,
 				E3E16DD2229321D90087197A /* TIOModelTrainerTests.m in Sources */,
 				E31C799A212E06CF00139C90 /* TensorIOTFLiteModelIntegrationTests.mm in Sources */,

--- a/Example/Tests/TIOMockTrainableModel.h
+++ b/Example/Tests/TIOMockTrainableModel.h
@@ -65,9 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly) NSString *backend;
 @property (readonly) TIOModelModes *modes;
 @property (readonly) BOOL loaded;
-
-@property (readonly) NSArray<TIOLayerInterface*> *inputs;
-@property (readonly) NSArray<TIOLayerInterface*> *outputs;
+@property (readonly) TIOModelIO *io;
 
 - (nullable instancetype)initWithBundle:(TIOModelBundle*)bundle NS_DESIGNATED_INITIALIZER;
 
@@ -78,11 +76,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id<TIOData>)runOn:(id<TIOData>)input;
 
-- (id<TIOLayerDescription>)descriptionOfInputAtIndex:(NSUInteger)index;
-- (id<TIOLayerDescription>)descriptionOfInputWithName:(NSString*)name;
+@property (readonly) NSArray<TIOLayerInterface*> *inputs __attribute__((deprecated));
+@property (readonly) NSArray<TIOLayerInterface*> *outputs __attribute__((deprecated));
 
-- (id<TIOLayerDescription>)descriptionOfOutputAtIndex:(NSUInteger)index;
-- (id<TIOLayerDescription>)descriptionOfOutputWithName:(NSString*)name;
+- (id<TIOLayerDescription>)descriptionOfInputAtIndex:(NSUInteger)index __attribute__((deprecated));
+- (id<TIOLayerDescription>)descriptionOfInputWithName:(NSString*)name __attribute__((deprecated));
+
+- (id<TIOLayerDescription>)descriptionOfOutputAtIndex:(NSUInteger)index __attribute__((deprecated));
+- (id<TIOLayerDescription>)descriptionOfOutputWithName:(NSString*)name __attribute__((deprecated));
 
 // MARK: - TIOTrainableModel
 

--- a/Example/Tests/TIOModelIOTests.m
+++ b/Example/Tests/TIOModelIOTests.m
@@ -1,0 +1,125 @@
+//
+//  TIOModelIOTests.m
+//  TensorIO_Tests
+//
+//  Created by Phil Dow on 6/26/19.
+//  Copyright © 2019 doc.ai (http://doc.ai)
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <XCTest/XCTest.h>
+#import <TensorIO/TensorIO-umbrella.h>
+
+@interface TIOModelIOTests : XCTestCase
+
+@property TIOLayerInterface *fooIn;
+@property TIOLayerInterface *barIn;
+@property TIOLayerInterface *fooOut;
+@property TIOLayerInterface *barOut;
+
+@end
+
+@implementation TIOModelIOTests
+
+- (void)setUp {
+    self.fooIn = [[TIOLayerInterface alloc] initWithName:@"foo" isInput:YES vectorDescription:[[TIOVectorLayerDescription alloc]
+        initWithShape:@[@(1)]
+        batched:NO
+        dtype:TIODataTypeFloat32
+        labels:nil
+        quantized:NO
+        quantizer:nil
+        dequantizer:nil]];
+    self.barIn = [[TIOLayerInterface alloc] initWithName:@"bar" isInput:YES vectorDescription:[[TIOVectorLayerDescription alloc]
+        initWithShape:@[@(1)]
+        batched:NO
+        dtype:TIODataTypeFloat32
+        labels:nil
+        quantized:NO
+        quantizer:nil
+        dequantizer:nil]];
+    self.fooOut = [[TIOLayerInterface alloc] initWithName:@"foo" isInput:NO vectorDescription:[[TIOVectorLayerDescription alloc]
+        initWithShape:@[@(1)]
+        batched:NO
+        dtype:TIODataTypeFloat32
+        labels:nil
+        quantized:NO
+        quantizer:nil
+        dequantizer:nil]];
+    self.barOut = [[TIOLayerInterface alloc] initWithName:@"bar" isInput:NO vectorDescription:[[TIOVectorLayerDescription alloc]
+        initWithShape:@[@(1)]
+        batched:NO
+        dtype:TIODataTypeFloat32
+        labels:nil
+        quantized:NO
+        quantizer:nil
+        dequantizer:nil]];
+}
+
+- (void)tearDown { }
+
+// MARK: -
+
+- (void)testModelIOPreservesIndex {
+    TIOModelIO *io = [[TIOModelIO alloc] initWithInputInterfaces:@[self.fooIn, self.barIn] ouputInterfaces:@[self.fooOut, self.barOut]];
+    
+    XCTAssertEqualObjects(io.inputs[0], self.fooIn);
+    XCTAssertEqualObjects(io.inputs[1], self.barIn);
+    
+    XCTAssertEqualObjects(io.outputs[0], self.fooOut);
+    XCTAssertEqualObjects(io.outputs[1], self.barOut);
+}
+
+- (void)testModelIOPreservesName {
+    TIOModelIO *io = [[TIOModelIO alloc] initWithInputInterfaces:@[self.fooIn, self.barIn] ouputInterfaces:@[self.fooOut, self.barOut]];
+    
+    XCTAssertEqualObjects(io.inputs[@"foo"], self.fooIn);
+    XCTAssertEqualObjects(io.inputs[@"bar"], self.barIn);
+    
+    XCTAssertEqualObjects(io.outputs[@"foo"], self.fooOut);
+    XCTAssertEqualObjects(io.outputs[@"bar"], self.barOut);
+}
+
+- (void)testModelIOReturnsAllObject {
+    TIOModelIO *io = [[TIOModelIO alloc] initWithInputInterfaces:@[self.fooIn, self.barIn] ouputInterfaces:@[self.fooOut, self.barOut]];
+    
+    XCTAssertEqualObjects(io.inputs.all, (@[self.fooIn, self.barIn]));
+    XCTAssertEqualObjects(io.outputs.all, (@[self.fooOut, self.barOut]));
+}
+
+- (void)testModelIOReturnsAllKeys {
+    TIOModelIO *io = [[TIOModelIO alloc] initWithInputInterfaces:@[self.fooIn, self.barIn] ouputInterfaces:@[self.fooOut, self.barOut]];
+    
+    XCTAssertEqualObjects([NSSet setWithArray:io.inputs.keys], ([NSSet setWithArray:@[@"foo", @"bar"]]));
+    XCTAssertEqualObjects([NSSet setWithArray:io.outputs.keys], ([NSSet setWithArray:@[@"foo", @"bar"]]));
+}
+
+- (void)testModelIOCountIsCorrect {
+    TIOModelIO *io = [[TIOModelIO alloc] initWithInputInterfaces:@[self.fooIn, self.barIn] ouputInterfaces:@[self.fooOut, self.barOut]];
+    
+    XCTAssert(io.inputs.count == 2);
+    XCTAssert(io.outputs.count == 2);
+}
+
+- (void)testReturnsIndexForName {
+    TIOModelIO *io = [[TIOModelIO alloc] initWithInputInterfaces:@[self.fooIn, self.barIn] ouputInterfaces:@[self.fooOut, self.barOut]];
+    
+    XCTAssert([io.inputs indexForName:@"foo"].integerValue == 0);
+    XCTAssert([io.inputs indexForName:@"bar"].integerValue == 1);
+    
+    XCTAssert([io.outputs indexForName:@"foo"].integerValue == 0);
+    XCTAssert([io.outputs indexForName:@"bar"].integerValue == 1);
+}
+
+@end

--- a/Example/Tests/TensorIOTFLiteModelIntegrationTests.mm
+++ b/Example/Tests/TensorIOTFLiteModelIntegrationTests.mm
@@ -80,8 +80,8 @@
     
     // Ensure inputs and outputs return correct count
     
-    XCTAssert(model.inputs.count == 1);
-    XCTAssert(model.outputs.count == 1);
+    XCTAssert(model.io.inputs.count == 1);
+    XCTAssert(model.io.outputs.count == 1);
     
     // Run the model on a number
     
@@ -130,8 +130,8 @@
     
     // Ensure inputs and outputs return correct count
     
-    XCTAssert(model.inputs.count == 1);
-    XCTAssert(model.outputs.count == 1);
+    XCTAssert(model.io.inputs.count == 1);
+    XCTAssert(model.io.outputs.count == 1);
     
     // Expected output
     
@@ -164,8 +164,8 @@
     
     // Ensure inputs and outputs return correct count
     
-    XCTAssert(model.inputs.count == 2);
-    XCTAssert(model.outputs.count == 2);
+    XCTAssert(model.io.inputs.count == 2);
+    XCTAssert(model.io.outputs.count == 2);
     
     // Run model on number
     
@@ -218,8 +218,8 @@
     
     // Ensure inputs and outputs return correct count
     
-    XCTAssert(model.inputs.count == 2);
-    XCTAssert(model.outputs.count == 2);
+    XCTAssert(model.io.inputs.count == 2);
+    XCTAssert(model.io.outputs.count == 2);
     
     // Expected outputs
     
@@ -293,8 +293,8 @@
     
     // Ensure inputs and outputs return correct count
     
-    XCTAssert(model.inputs.count == 1);
-    XCTAssert(model.outputs.count == 1);
+    XCTAssert(model.io.inputs.count == 1);
+    XCTAssert(model.io.outputs.count == 1);
     
     // Expected outputs
     
@@ -342,8 +342,8 @@
     
     // Ensure inputs and outputs return correct count
     
-    XCTAssert(model.inputs.count == 1);
-    XCTAssert(model.outputs.count == 1);
+    XCTAssert(model.io.inputs.count == 1);
+    XCTAssert(model.io.outputs.count == 1);
     
     // Create ARGB bytes
     
@@ -429,8 +429,8 @@
     
     // Ensure inputs and outputs return correct count
     
-    XCTAssert(model.inputs.count == 1);
-    XCTAssert(model.outputs.count == 1);
+    XCTAssert(model.io.inputs.count == 1);
+    XCTAssert(model.io.outputs.count == 1);
     
     // Create ARGB bytes
     
@@ -520,8 +520,8 @@
     
     // Ensure inputs and outputs return correct count
     
-    XCTAssert(model.inputs.count == 1);
-    XCTAssert(model.outputs.count == 1);
+    XCTAssert(model.io.inputs.count == 1);
+    XCTAssert(model.io.outputs.count == 1);
     
     // Prepare image input
     
@@ -562,8 +562,8 @@
     
     // Ensure inputs and outputs return correct count
     
-    XCTAssert(model.inputs.count == 1);
-    XCTAssert(model.outputs.count == 1);
+    XCTAssert(model.io.inputs.count == 1);
+    XCTAssert(model.io.outputs.count == 1);
     
     // Prepare image input
     
@@ -607,8 +607,8 @@
     
     // Ensure inputs and outputs return correct count
     
-    XCTAssert(model.inputs.count == 1);
-    XCTAssert(model.outputs.count == 1);
+    XCTAssert(model.io.inputs.count == 1);
+    XCTAssert(model.io.outputs.count == 1);
     
     // Prepare image input
     
@@ -665,8 +665,8 @@
     
     // Ensure inputs and outputs return correct count
     
-    XCTAssert(model.inputs.count == 1);
-    XCTAssert(model.outputs.count == 1);
+    XCTAssert(model.io.inputs.count == 1);
+    XCTAssert(model.io.outputs.count == 1);
     
     // Run the model on a number
     
@@ -688,8 +688,8 @@
     
     // Ensure inputs and outputs return correct count
     
-    XCTAssert(model.inputs.count == 1);
-    XCTAssert(model.outputs.count == 1);
+    XCTAssert(model.io.inputs.count == 1);
+    XCTAssert(model.io.outputs.count == 1);
     
     // Run the model on a number
     
@@ -745,8 +745,8 @@
     
     // Ensure inputs and outputs return correct count
     
-    XCTAssert(model.inputs.count == 2);
-    XCTAssert(model.outputs.count == 2);
+    XCTAssert(model.io.inputs.count == 2);
+    XCTAssert(model.io.outputs.count == 2);
     
     // Run model on number
     

--- a/TensorIO/Classes/Core/TIOModel/TIOModel.h
+++ b/TensorIO/Classes/Core/TIOModel/TIOModel.h
@@ -29,6 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class TIOModelOptions;
 @class TIOModelModes;
 @class TIOBatch;
+@class TIOModelIO;
 
 /**
  * An Obj-C wrapper around lower level, usually C++ model implementations. This is the primary
@@ -153,16 +154,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly) BOOL loaded;
 
 /**
- * Returns descriptions of the model's inputs indexed to the order they appear in model.json.
+ * Contains the descriptions of the model's inputs and outputs accessible by
+ * numeric index or by name:
+ *
+ * @code
+ * io.inputs[0]
+ * io.inputs[@"image"]
+ * io.outputs[0]
+ * io.outputs[@"label"]
+ * @endcode
  */
 
-@property (readonly) NSArray<TIOLayerInterface*> *inputs;
+@property (readonly) TIOModelIO *io;
+
+/**
+ * Returns descriptions of the model's inputs indexed to the order they appear in model.json.
+ * This attribute is deprecated. Use `io` instead.
+ */
+
+@property (readonly) NSArray<TIOLayerInterface*> *inputs __attribute__((deprecated));
 
 /**
  * Returns descriptions of the model's outputs indexed to the order they appear in model.json.
+ * This attribute is deprecated. Use `io` instead.
  */
 
-@property (readonly) NSArray<TIOLayerInterface*> *outputs;
+@property (readonly) NSArray<TIOLayerInterface*> *outputs __attribute__((deprecated));
 
  // MARK: - Initialization
 

--- a/TensorIO/Classes/Core/TIOModel/TIOModelBundle.h
+++ b/TensorIO/Classes/Core/TIOModel/TIOModelBundle.h
@@ -24,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class TIOModelOptions;
 @class TIOModelModes;
+@class TIOModelIO;
 @protocol TIOModel;
 
 /**
@@ -157,6 +158,20 @@ extern NSString * const TIOModelAssetsDirectory;
  */
 
 @property (readonly) TIOModelOptions *options;
+
+/**
+ * Contains the descriptions of the model's inputs and outputs accessible by
+ * numeric index or by name:
+ *
+ * @code
+ * io.inputs[0]
+ * io.inputs[@"image"]
+ * io.outputs[0]
+ * io.outputs[@"label"]
+ * @endcode
+ */
+
+@property (readonly) TIOModelIO *io;
 
 /**
  * The file path to the actual underlying model contained in this bundle.

--- a/TensorIO/Classes/Core/TIOModel/TIOModelBundle.mm
+++ b/TensorIO/Classes/Core/TIOModel/TIOModelBundle.mm
@@ -187,9 +187,9 @@ NSString * const TIOModelAssetsDirectory = @"assets";
         TIOLayerInterface *interface;
         
         if ( [type isEqualToString:kTensorTypeVector] ) {
-            interface = TIOTFLiteModelParseTIOVectorDescription(input, isInput, isQuantized, self);
+            interface = TIOModelParseTIOVectorDescription(input, isInput, isQuantized, self);
         } else if ( [type isEqualToString:kTensorTypeImage] ) {
-            interface = TIOTFLiteModelParseTIOPixelBufferDescription(input, isInput, isQuantized);
+            interface = TIOModelParseTIOPixelBufferDescription(input, isInput, isQuantized);
         }
         
         if ( interface == nil ) {

--- a/TensorIO/Classes/Core/TIOModel/TIOModelBundle.mm
+++ b/TensorIO/Classes/Core/TIOModel/TIOModelBundle.mm
@@ -25,6 +25,7 @@
 #import "TIOPlaceholderModel.h"
 #import "TIOModelBackend.h"
 #import "TIOModelModes.h"
+#import "TIOModel.h"
 
 NSString * const TIOTFModelBundleExtension = @"tfbundle";
 NSString * const TIOModelBundleExtension = @"tiobundle";

--- a/TensorIO/Classes/Core/TIOModel/TIOModelIO.h
+++ b/TensorIO/Classes/Core/TIOModel/TIOModelIO.h
@@ -1,0 +1,149 @@
+//
+//  TIOModelIO.h
+//  TensorIO
+//
+//  Created by Phil Dow on 6/25/19.
+//  Copyright © 2019 doc.ai (http://doc.ai)
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class TIOLayerInterface;
+@class TIOModelIOList;
+
+/**
+ * Encapsulates information about the inputs and outputs to a model.
+ */
+
+@interface TIOModelIO : NSObject
+
+/**
+ * Initializes an instance of TIOModelIO with input and output interfaces.
+ */
+
+- (instancetype)initWithInputInterfaces:(NSArray<TIOLayerInterface*> *)inputInterfaces ouputInterfaces:(NSArray<TIOLayerInterface*> *)outputInterfaces NS_DESIGNATED_INITIALIZER;
+
+/**
+ * Use the designated initializer.
+ */
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/**
+ * The inputs list. Access the values in this list using indexed subscripting
+ * by name or by key.
+ *
+ * @code
+ * inputs[0]
+ * inputs[@"image"]
+ * @endcode
+ */
+
+@property (readonly) TIOModelIOList *inputs;
+
+/**
+ * The outputs list. Access the values in this list using indexed subscripting
+ * by name or by key.
+ *
+ * @code
+ * outputs[0]
+ * outputs[@"label"]
+ * @endcode
+ */
+
+@property (readonly) TIOModelIOList *outputs;
+
+@end
+
+// MARK: -
+
+/**
+ * An I/O list may be indexed by key or by index.
+ */
+
+@interface TIOModelIOList : NSObject
+
+/**
+ * Initializes an indexed model list with a list interfaces. You should not
+ * need to create instances of this class yourself.
+ */
+
+- (instancetype)initWithLayerInterfaces:(NSArray<TIOLayerInterface*> *)interfaces NS_DESIGNATED_INITIALIZER;
+
+/**
+ * Use the designated initializer.
+ */
+
+- (instancetype)init NS_UNAVAILABLE;
+
+// MARK: -
+
+/**
+ * The number of items in the list.
+ */
+
+@property (readonly) NSUInteger count;
+
+/**
+ * All items in the list as an array.
+ */
+
+@property (readonly) NSArray<TIOLayerInterface*> *all;
+
+/**
+ * All of the keys (names) in the list.
+ */
+
+@property (readonly) NSArray<NSString*> *keys;
+
+/**
+ * Returns the numeric index for the named index.
+ */
+
+- (NSNumber *)indexForName:(NSString *)name;
+
+// MARK: -
+
+/**
+ * Returns the `TIOLayerInterface` for the I/O at a numeric index, or raises an
+ * exception if no interface is available at the index.
+ */
+
+- (TIOLayerInterface *)objectAtIndexedSubscript:(NSInteger)idx;
+
+/**
+ * Raises an exception. List values are read-only.
+ */
+
+- (void)setObject:(TIOLayerInterface *)obj atIndexedSubscript:(NSInteger)idx;
+
+/**
+ * Returns the `TIOLayerInterface` for the I/O at a named index, or raises an
+ * exception if no interface is available at the index.
+ */
+
+- (TIOLayerInterface *)objectForKeyedSubscript:(NSString *)key;
+
+/**
+ * Raises an exception. List values are read-only.
+ */
+
+- (void)setObject:(TIOLayerInterface *)obj forKeyedSubscript:(NSString *)key;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/TensorIO/Classes/Core/TIOModel/TIOModelIO.m
+++ b/TensorIO/Classes/Core/TIOModel/TIOModelIO.m
@@ -1,0 +1,99 @@
+//
+//  TIOModelIO.m
+//  TensorIO
+//
+//  Created by Phil Dow on 6/25/19.
+//  Copyright © 2019 doc.ai (http://doc.ai)
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "TIOModelIO.h"
+#import "TIOLayerInterface.h"
+
+@implementation TIOModelIO
+
+- (instancetype)initWithInputInterfaces:(NSArray<TIOLayerInterface*> *)inputInterfaces ouputInterfaces:(NSArray<TIOLayerInterface*> *)outputInterfaces {
+    if ((self = [super init])) {
+        _inputs = [[TIOModelIOList alloc] initWithLayerInterfaces:inputInterfaces];
+        _outputs = [[TIOModelIOList alloc] initWithLayerInterfaces:outputInterfaces];
+    }
+    return self;
+}
+
+@end
+
+// MARK: -
+
+@implementation TIOModelIOList {
+    NSArray<TIOLayerInterface*> *_indexedInterfaces;
+    NSDictionary<NSString*,TIOLayerInterface*> *_namedInterfaces;
+    NSDictionary<NSString*,NSNumber*> *_nameToIndex;
+}
+
+- (instancetype)initWithLayerInterfaces:(NSArray<TIOLayerInterface*> *)interfaces {
+    if ((self=[super init])) {
+        _indexedInterfaces = interfaces;
+        
+        NSMutableDictionary *namedInterfaces = NSMutableDictionary.dictionary;
+        NSMutableDictionary *nameToIndex = NSMutableDictionary.dictionary;
+        
+        [interfaces enumerateObjectsUsingBlock:^(TIOLayerInterface * _Nonnull interface, NSUInteger idx, BOOL * _Nonnull stop) {
+            namedInterfaces[interface.name] = interface;
+            nameToIndex[interface.name] = @(idx);
+        }];
+        
+        _namedInterfaces = namedInterfaces.copy;
+        _nameToIndex = nameToIndex.copy;
+        
+    }
+    return self;
+}
+
+// MARK: -
+
+- (NSUInteger)count {
+    return _indexedInterfaces.count;
+}
+
+- (NSArray<TIOLayerInterface*> *)all {
+    return _indexedInterfaces;
+}
+
+- (NSArray<NSString*> *)keys {
+    return _namedInterfaces.allKeys;
+}
+
+- (NSNumber *)indexForName:(NSString *)name {
+    return _nameToIndex[name];
+}
+
+// MARK: -
+
+- (TIOLayerInterface *)objectAtIndexedSubscript:(NSInteger)idx {
+    return _indexedInterfaces[idx];
+}
+
+- (void)setObject:(TIOLayerInterface *)obj atIndexedSubscript:(NSInteger)idx {
+    NSAssert(NO, @"Writing to an indexed subscript is not supported.");
+}
+
+- (TIOLayerInterface *)objectForKeyedSubscript:(NSString *)key {
+    return _namedInterfaces[key];
+}
+
+- (void)setObject:(TIOLayerInterface *)obj forKeyedSubscript:(NSString *)key {
+    NSAssert(NO, @"Writing to an indexed subscript is not supported.");
+}
+
+@end

--- a/TensorIO/Classes/Core/TIOModel/TIOModelJSONParsing.h
+++ b/TensorIO/Classes/Core/TIOModel/TIOModelJSONParsing.h
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @return TIOLayerInterface An interface that describes this pixel buffer input or output.
  */
 
-TIOLayerInterface * _Nullable TIOTFLiteModelParseTIOVectorDescription(NSDictionary *dict, BOOL isInput, BOOL quantized, TIOModelBundle *bundle);
+TIOLayerInterface * _Nullable TIOModelParseTIOVectorDescription(NSDictionary *dict, BOOL isInput, BOOL quantized, TIOModelBundle *bundle);
 
 /**
  * Parses the JSON description of a pixel buffer input or output.
@@ -60,7 +60,7 @@ TIOLayerInterface * _Nullable TIOTFLiteModelParseTIOVectorDescription(NSDictiona
  * @return TIOLayerInterface An interface that describes this pixel buffer input or output.
  */
 
-TIOLayerInterface * _Nullable TIOTFLiteModelParseTIOPixelBufferDescription(NSDictionary *dict, BOOL isInput, BOOL quantized);
+TIOLayerInterface * _Nullable TIOModelParseTIOPixelBufferDescription(NSDictionary *dict, BOOL isInput, BOOL quantized);
 
 /**
  * Parses the `quantization` key of an input description and returns an associated data quantizer.

--- a/TensorIO/Classes/Core/TIOModel/TIOModelJSONParsing.mm
+++ b/TensorIO/Classes/Core/TIOModel/TIOModelJSONParsing.mm
@@ -44,7 +44,7 @@ static NSError * const kTIOParserInvalidDequantizerError = [NSError errorWithDom
 
 // MARK: -
 
-TIOLayerInterface * _Nullable TIOTFLiteModelParseTIOVectorDescription(NSDictionary *dict, BOOL isInput, BOOL quantized, TIOModelBundle *bundle) {
+TIOLayerInterface * _Nullable TIOModelParseTIOVectorDescription(NSDictionary *dict, BOOL isInput, BOOL quantized, TIOModelBundle *bundle) {
     NSArray<NSNumber*> *shape = dict[@"shape"];
     BOOL batched = shape[0].integerValue == -1;
     
@@ -114,7 +114,7 @@ TIOLayerInterface * _Nullable TIOTFLiteModelParseTIOVectorDescription(NSDictiona
     return interface;
 }
 
-TIOLayerInterface * _Nullable TIOTFLiteModelParseTIOPixelBufferDescription(NSDictionary *dict, BOOL isInput, BOOL quantized) {
+TIOLayerInterface * _Nullable TIOModelParseTIOPixelBufferDescription(NSDictionary *dict, BOOL isInput, BOOL quantized) {
     NSArray<NSNumber*> *shape = dict[@"shape"];
     BOOL batched = shape[0].integerValue == -1;
     

--- a/TensorIO/Classes/Core/TIOModel/TIOPlaceholderModel.h
+++ b/TensorIO/Classes/Core/TIOModel/TIOPlaceholderModel.h
@@ -26,6 +26,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class TIOModelIO;
+
 /**
  * A placeholder model declares an interface but does not contain any underlying model
  * implementation. It is used to gather labeled data for a model that has not been trained
@@ -51,9 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly) NSString *backend;
 @property (readonly) TIOModelModes *modes;
 @property (readonly) BOOL loaded;
-
-@property (readonly) NSArray<TIOLayerInterface*> *inputs;
-@property (readonly) NSArray<TIOLayerInterface*> *outputs;
+@property (readonly) TIOModelIO *io;
 
 // Model Protocol Methods
 
@@ -66,11 +66,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id<TIOData>)runOn:(id<TIOData>)input;
 
-- (id<TIOLayerDescription>)descriptionOfInputAtIndex:(NSUInteger)index;
-- (id<TIOLayerDescription>)descriptionOfInputWithName:(NSString*)name;
+// TODO: Where are these used? Can we deprecate them? By the data collection UI?
+// Use `io` instead
 
-- (id<TIOLayerDescription>)descriptionOfOutputAtIndex:(NSUInteger)index;
-- (id<TIOLayerDescription>)descriptionOfOutputWithName:(NSString*)name;
+@property (readonly) NSArray<TIOLayerInterface*> *inputs __attribute__((deprecated));
+@property (readonly) NSArray<TIOLayerInterface*> *outputs __attribute__((deprecated));
+
+- (id<TIOLayerDescription>)descriptionOfInputAtIndex:(NSUInteger)index __attribute__((deprecated));
+- (id<TIOLayerDescription>)descriptionOfInputWithName:(NSString*)name __attribute__((deprecated));
+
+- (id<TIOLayerDescription>)descriptionOfOutputAtIndex:(NSUInteger)index __attribute__((deprecated));
+- (id<TIOLayerDescription>)descriptionOfOutputWithName:(NSString*)name __attribute__((deprecated));
 
 @end
 

--- a/TensorIO/Classes/Core/TIOModel/TIOPlaceholderModel.mm
+++ b/TensorIO/Classes/Core/TIOModel/TIOPlaceholderModel.mm
@@ -30,22 +30,7 @@
 #import "TIOModelJSONParsing.h"
 #import "TIOModelIO.h"
 
-static NSString * const kTensorTypeVector = @"array";
-static NSString * const kTensorTypeImage = @"image";
-
-@implementation TIOPlaceholderModel {
-    // Index to Interface Description
-    NSArray<TIOLayerInterface*> *_indexedInputInterfaces;
-    NSArray<TIOLayerInterface*> *_indexedOutputInterfaces;
-    
-    // Name to Interface Description
-    NSDictionary<NSString*,TIOLayerInterface*> *_namedInputInterfaces;
-    NSDictionary<NSString*,TIOLayerInterface*> *_namedOutputInterfaces;
-    
-    // Name to Index
-    NSDictionary<NSString*,NSNumber*> *_namedInputToIndex;
-    NSDictionary<NSString*,NSNumber*> *_namedOutputToIndex;
-}
+@implementation TIOPlaceholderModel
 
 + (nullable instancetype)modelWithBundleAtPath:(NSString*)path {
     return [[[TIOModelBundle alloc] initWithPath:path] newModel];

--- a/TensorIO/Classes/Core/TIOModel/TIOPlaceholderModel.mm
+++ b/TensorIO/Classes/Core/TIOModel/TIOPlaceholderModel.mm
@@ -27,7 +27,6 @@
 #import "TIOLayerDescription.h"
 #import "TIOPixelBufferLayerDescription.h"
 #import "TIOVectorLayerDescription.h"
-#import "TIOModelJSONParsing.h"
 #import "TIOModelIO.h"
 
 @implementation TIOPlaceholderModel
@@ -55,70 +54,10 @@
         _placeholder = bundle.placeholder;
         _quantized = bundle.quantized;
         _type = bundle.type;
-        
-        // Input and output parsing
-        
-        NSArray<TIOLayerInterface*> *inputInterfaces = [self _parseIO:bundle.info[@"inputs"] isInput:YES];
-        
-        if ( !inputInterfaces ) {
-            NSLog(@"Unable to parse input field in model.json");
-            return nil;
-        }
-        
-        NSArray<TIOLayerInterface*> *outputInterfaces = [self _parseIO:bundle.info[@"outputs"] isInput:NO];
-        
-        if ( !outputInterfaces ) {
-            NSLog(@"Unable to parse output field in model.json");
-            return nil;
-        }
-        
-        _io = [[TIOModelIO alloc] initWithInputInterfaces:inputInterfaces ouputInterfaces:outputInterfaces];
+        _io = bundle.io;
     }
     
     return self;
-}
-
-// MARK: - JSON Parsing
-// TODO: Move JSON Parsing to an external function or to the model bundle class
-
-/**
- * Enumerates through the JSON description of a model's inputs or outputs and
- * constructs a `TIOLayerInterface` for each one.
- *
- * @param io An array of dictionaries describing the model's input or output layers
- * @param isInput A boolean value indicating if the io descriptions or for the input or output
- * @return NSArray An array of `TIOLayerInterface` matching the descriptions, or `nil` if parsing failed
- */
-
-- (nullable NSArray<TIOLayerInterface*> *)_parseIO:(NSArray<NSDictionary<NSString*,id>*>*)io isInput:(BOOL)isInput {
-    
-    static NSString * const kTensorTypeVector = @"array";
-    static NSString * const kTensorTypeImage = @"image";
-    
-    NSMutableArray<TIOLayerInterface*> *interfaces = NSMutableArray.array;
-    BOOL isQuantized = self.quantized;
-    
-    __block BOOL error = NO;
-    [io enumerateObjectsUsingBlock:^(NSDictionary<NSString *,id> * _Nonnull input, NSUInteger idx, BOOL * _Nonnull stop) {
-        NSString *type = input[@"type"];
-        TIOLayerInterface *interface;
-        
-        if ( [type isEqualToString:kTensorTypeVector] ) {
-            interface = TIOTFLiteModelParseTIOVectorDescription(input, isInput, isQuantized, self->_bundle);
-        } else if ( [type isEqualToString:kTensorTypeImage] ) {
-            interface = TIOTFLiteModelParseTIOPixelBufferDescription(input, isInput, isQuantized);
-        }
-        
-        if ( interface == nil ) {
-            error = YES;
-            *stop = YES;
-            return;
-        }
-        
-        [interfaces addObject:interface];
-    }];
-    
-    return error ? nil : interfaces.copy;
 }
 
 // MARK: - Model Memory Management

--- a/TensorIO/Classes/TFLite/TIOTFLiteModel/TIOTFLiteModel.h
+++ b/TensorIO/Classes/TFLite/TIOTFLiteModel/TIOTFLiteModel.h
@@ -25,6 +25,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class TIOModelIO;
+
 /**
  * An Objective-C wrapper around TensorFlow lite models that provides a unified interface to the
  * input and output layers of the underlying model.
@@ -52,9 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly) NSString *backend;
 @property (readonly) TIOModelModes *modes;
 @property (readonly) BOOL loaded;
-
-@property (readonly) NSArray<TIOLayerInterface*> *inputs;
-@property (readonly) NSArray<TIOLayerInterface*> *outputs;
+@property (readonly) TIOModelIO *io;
 
 // Model Protocol Methods
 
@@ -81,11 +81,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id<TIOData>)run:(TIOBatch *)batch error:(NSError * _Nullable *)error;
 
-- (id<TIOLayerDescription>)descriptionOfInputAtIndex:(NSUInteger)index;
-- (id<TIOLayerDescription>)descriptionOfInputWithName:(NSString*)name;
+// TODO: Where are these used? Can we deprecate them? By the data collection UI?
+// Use `io` instead
 
-- (id<TIOLayerDescription>)descriptionOfOutputAtIndex:(NSUInteger)index;
-- (id<TIOLayerDescription>)descriptionOfOutputWithName:(NSString*)name;
+@property (readonly) NSArray<TIOLayerInterface*> *inputs __attribute__((deprecated));
+@property (readonly) NSArray<TIOLayerInterface*> *outputs __attribute__((deprecated));
+
+- (id<TIOLayerDescription>)descriptionOfInputAtIndex:(NSUInteger)index __attribute__((deprecated));
+- (id<TIOLayerDescription>)descriptionOfInputWithName:(NSString*)name __attribute__((deprecated));
+
+- (id<TIOLayerDescription>)descriptionOfOutputAtIndex:(NSUInteger)index __attribute__((deprecated));
+- (id<TIOLayerDescription>)descriptionOfOutputWithName:(NSString*)name __attribute__((deprecated));
 
 @end
 

--- a/TensorIO/Classes/TFLite/TIOTFLiteModel/TIOTFLiteModel.mm
+++ b/TensorIO/Classes/TFLite/TIOTFLiteModel/TIOTFLiteModel.mm
@@ -43,7 +43,6 @@
 #import "NSDictionary+TIOTFLiteData.h"
 #import "TIOPixelBuffer+TIOTFLiteData.h"
 #import "NSArray+TIOExtensions.h"
-#import "TIOModelJSONParsing.h"
 #import "TIOBatch.h"
 #import "TIOModelIO.h"
 
@@ -77,70 +76,10 @@
         _type = bundle.type;
         _backend = bundle.backend;
         _modes = bundle.modes;
-        
-        // Input and output parsing
-        
-        NSArray<TIOLayerInterface*> *inputInterfaces = [self _parseIO:bundle.info[@"inputs"] isInput:YES];
-        
-        if ( !inputInterfaces ) {
-            NSLog(@"Unable to parse input field in model.json");
-            return nil;
-        }
-        
-        NSArray<TIOLayerInterface*> *outputInterfaces = [self _parseIO:bundle.info[@"outputs"] isInput:NO];
-        
-        if ( !outputInterfaces ) {
-            NSLog(@"Unable to parse output field in model.json");
-            return nil;
-        }
-        
-        _io = [[TIOModelIO alloc] initWithInputInterfaces:inputInterfaces ouputInterfaces:outputInterfaces];
+        _io = bundle.io;
     }
     
     return self;
-}
-
-// MARK: - JSON Parsing
-// TODO: Move JSON Parsing to an external function or to the model bundle class
-
-/**
- * Enumerates through the JSON description of a model's inputs or outputs and
- * constructs a `TIOLayerInterface` for each one.
- *
- * @param io An array of dictionaries describing the model's input or output layers
- * @param isInput A boolean value indicating if the io descriptions or for the input or output
- * @return NSArray An array of `TIOLayerInterface` matching the descriptions, or `nil` if parsing failed
- */
-
-- (nullable NSArray<TIOLayerInterface*> *)_parseIO:(NSArray<NSDictionary<NSString*,id>*>*)io isInput:(BOOL)isInput {
-    
-    static NSString * const kTensorTypeVector = @"array";
-    static NSString * const kTensorTypeImage = @"image";
-    
-    NSMutableArray<TIOLayerInterface*> *interfaces = NSMutableArray.array;
-    BOOL isQuantized = self.quantized;
-    
-    __block BOOL error = NO;
-    [io enumerateObjectsUsingBlock:^(NSDictionary<NSString *,id> * _Nonnull input, NSUInteger idx, BOOL * _Nonnull stop) {
-        NSString *type = input[@"type"];
-        TIOLayerInterface *interface;
-        
-        if ( [type isEqualToString:kTensorTypeVector] ) {
-            interface = TIOTFLiteModelParseTIOVectorDescription(input, isInput, isQuantized, self->_bundle);
-        } else if ( [type isEqualToString:kTensorTypeImage] ) {
-            interface = TIOTFLiteModelParseTIOPixelBufferDescription(input, isInput, isQuantized);
-        }
-        
-        if ( interface == nil ) {
-            error = YES;
-            *stop = YES;
-            return;
-        }
-        
-        [interfaces addObject:interface];
-    }];
-    
-    return error ? nil : interfaces.copy;
 }
 
 // MARK: - Model Memory Management
@@ -408,7 +347,7 @@
  * Captures outputs from the model.
  *
  * @return TIOData A class that is appropriate to the model output. Currently all outputs are
- * wrapped in an instance of `NSDictionary` whose keys are taken from the json description of the
+ * wrapped in an instance of `NSDictionary` whose keys are taken from the JSON description of the
  * model outputs.
  */
 

--- a/TensorIO/Classes/TensorFlow/TIOTensorFlowModel/TIOTensorFlowModel.h
+++ b/TensorIO/Classes/TensorFlow/TIOTensorFlowModel/TIOTensorFlowModel.h
@@ -28,6 +28,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class TIOModelIO;
+
 /**
  * An Objective-C wrapper around TensorFlow models that provides a unified interface to the
  * input and output layers of the underlying model. These models are capable of
@@ -56,9 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly) NSString *backend;
 @property (readonly) TIOModelModes *modes;
 @property (readonly) BOOL loaded;
-
-@property (readonly) NSArray<TIOLayerInterface*> *inputs;
-@property (readonly) NSArray<TIOLayerInterface*> *outputs;
+@property (readonly) TIOModelIO *io;
 
 // MARK: - Model Protocol Methods
 
@@ -84,11 +84,17 @@ NS_ASSUME_NONNULL_BEGIN
 - (id<TIOData>)runOn:(id<TIOData>)input error:(NSError**)error;
 - (id<TIOData>)run:(TIOBatch *)batch error:(NSError * _Nullable *)error;
 
-- (id<TIOLayerDescription>)descriptionOfInputAtIndex:(NSUInteger)index;
-- (id<TIOLayerDescription>)descriptionOfInputWithName:(NSString*)name;
+// TODO: Where are these used? Can we deprecate them? By the data collection UI?
+// Use `io` instead
 
-- (id<TIOLayerDescription>)descriptionOfOutputAtIndex:(NSUInteger)index;
-- (id<TIOLayerDescription>)descriptionOfOutputWithName:(NSString*)name;
+@property (readonly) NSArray<TIOLayerInterface*> *inputs __attribute__((deprecated));
+@property (readonly) NSArray<TIOLayerInterface*> *outputs __attribute__((deprecated));
+
+- (id<TIOLayerDescription>)descriptionOfInputAtIndex:(NSUInteger)index __attribute__((deprecated));
+- (id<TIOLayerDescription>)descriptionOfInputWithName:(NSString*)name __attribute__((deprecated));
+
+- (id<TIOLayerDescription>)descriptionOfOutputAtIndex:(NSUInteger)index __attribute__((deprecated));
+- (id<TIOLayerDescription>)descriptionOfOutputWithName:(NSString*)name __attribute__((deprecated));
 
 @end
 

--- a/TensorIO/Classes/TensorFlow/TIOTensorFlowModel/TIOTensorFlowModel.mm
+++ b/TensorIO/Classes/TensorFlow/TIOTensorFlowModel/TIOTensorFlowModel.mm
@@ -52,9 +52,7 @@
 #import "TIOPixelBuffer+TIOTensorFlowData.h"
 #import "TIOTensorFlowErrors.h"
 #import "TIOModelModes.h"
-
-static NSString * const kTensorTypeVector = @"array";
-static NSString * const kTensorTypeImage = @"image";
+#import "TIOModelIO.h"
 
 typedef std::pair<std::string, tensorflow::Tensor> NamedTensor;
 typedef std::vector<NamedTensor> NamedTensors;
@@ -62,20 +60,7 @@ typedef std::vector<tensorflow::Tensor> Tensors;
 typedef std::vector<std::string> TensorNames;
 
 @implementation TIOTensorFlowModel {
-    @protected
     tensorflow::SavedModelBundle _saved_model_bundle;
-    
-    // Index to Interface Description
-    NSArray<TIOLayerInterface*> *_indexedInputInterfaces;
-    NSArray<TIOLayerInterface*> *_indexedOutputInterfaces;
-    
-    // Name to Interface Description
-    NSDictionary<NSString*,TIOLayerInterface*> *_namedInputInterfaces;
-    NSDictionary<NSString*,TIOLayerInterface*> *_namedOutputInterfaces;
-    
-    // Name to Index
-    NSDictionary<NSString*,NSNumber*> *_namedInputToIndex;
-    NSDictionary<NSString*,NSNumber*> *_namedOutputToIndex;
     
     // Training Support
     NSArray<NSString*> *_trainingOps;
@@ -109,31 +94,25 @@ typedef std::vector<std::string> TensorNames;
         
         // Input and output parsing
         
-        NSArray<NSDictionary<NSString*,id>*> *inputs = bundle.info[@"inputs"];
-        NSArray<NSDictionary<NSString*,id>*> *outputs = bundle.info[@"outputs"];
-        NSDictionary<NSString*,id> *train = bundle.info[@"train"];
+        NSArray<TIOLayerInterface*> *inputInterfaces = [self _parseIO:bundle.info[@"inputs"] isInput:YES];
         
-        if ( inputs == nil ) {
-            NSLog(@"Expected input array field in model.json, none found");
-            return nil;
-        }
-        
-        if ( outputs == nil ) {
-            NSLog(@"Expected output array field in model.json, none found");
-            return nil;
-        }
-        
-        if ( ![self _parseInputs:inputs] ) {
+        if ( !inputInterfaces ) {
             NSLog(@"Unable to parse input field in model.json");
             return nil;
         }
         
-        if ( ![self _parseOutputs:outputs] ) {
+        NSArray<TIOLayerInterface*> *outputInterfaces = [self _parseIO:bundle.info[@"outputs"] isInput:NO];
+        
+        if ( !outputInterfaces ) {
             NSLog(@"Unable to parse output field in model.json");
             return nil;
         }
         
-        if ( ![self _parseTrainingDict:train] ) {
+        _io = [[TIOModelIO alloc] initWithInputInterfaces:inputInterfaces ouputInterfaces:outputInterfaces];
+        
+        // Training parsing
+        
+        if ( ![self _parseTrainingDict:bundle.info[@"train"]] ) {
             NSLog(@"Unable to parse train field in model.json");
             return nil;
         }
@@ -142,38 +121,29 @@ typedef std::vector<std::string> TensorNames;
     return self;
 }
 
-- (instancetype)init {
-    self = [self initWithBundle:[[TIOModelBundle alloc] initWithPath:@""]];
-    NSAssert(NO, @"Use the designated initializer initWithBundle:");
-    return self;
-}
-
 // MARK: - JSON Parsing
+// TODO: Move JSON Parsing to an external function or to the model bundle class
 
 /**
- * Enumerates through the json described inputs and constructs a `TIOLayerInterface` for each one.
+ * Enumerates through the JSON description of a model's inputs or outputs and
+ * constructs a `TIOLayerInterface` for each one.
  *
- * @param inputs An array of dictionaries describing the model's input layers
- *
- * @return BOOL `YES` if the json descriptions were successfully parsed, `NO` otherwise
+ * @param io An array of dictionaries describing the model's input or output layers
+ * @param isInput A boolean value indicating if the io descriptions or for the input or output
+ * @return NSArray An array of `TIOLayerInterface` matching the descriptions, or `nil` if parsing failed
  */
 
-- (BOOL)_parseInputs:(NSArray<NSDictionary<NSString*,id>*>*)inputs {
+- (nullable NSArray<TIOLayerInterface*> *)_parseIO:(NSArray<NSDictionary<NSString*,id>*>*)io isInput:(BOOL)isInput {
     
-    auto *indexedInputInterfaces = [NSMutableArray<TIOLayerInterface*> array];
-    auto *namedInputInterfaces = [NSMutableDictionary<NSString*,TIOLayerInterface*> dictionary];
-    auto *namedInputToIndex = [NSMutableDictionary<NSString*,NSNumber*> dictionary];
+    static NSString * const kTensorTypeVector = @"array";
+    static NSString * const kTensorTypeImage = @"image";
     
-    auto isQuantized = self.quantized;
-    auto isInput = YES;
+    NSMutableArray<TIOLayerInterface*> *interfaces = NSMutableArray.array;
+    BOOL isQuantized = self.quantized;
     
     __block BOOL error = NO;
-    
-    [inputs enumerateObjectsUsingBlock:^(NSDictionary<NSString *,id> * _Nonnull input, NSUInteger idx, BOOL * _Nonnull stop) {
-        
+    [io enumerateObjectsUsingBlock:^(NSDictionary<NSString *,id> * _Nonnull input, NSUInteger idx, BOOL * _Nonnull stop) {
         NSString *type = input[@"type"];
-        NSString *name = input[@"name"];
-        
         TIOLayerInterface *interface;
         
         if ( [type isEqualToString:kTensorTypeVector] ) {
@@ -188,73 +158,16 @@ typedef std::vector<std::string> TensorNames;
             return;
         }
         
-        [indexedInputInterfaces addObject:interface];
-        namedInputInterfaces[name] = interface;
-        namedInputToIndex[name] = @(idx);
+        [interfaces addObject:interface];
     }];
     
-    _indexedInputInterfaces = indexedInputInterfaces.copy;
-    _namedInputInterfaces = namedInputInterfaces.copy;
-    _namedInputToIndex = namedInputToIndex.copy;
-    
-    return !error;
-}
-
-/**
- * Enumerates through the json described outputs and constructs a `TIOLayerInterface` for each one.
- *
- * @param outputs An array of dictionaries describing the model's output layers
- *
- * @return BOOL `YES` if the json descriptions were successfully parsed, `NO` otherwise
- */
-
-- (BOOL)_parseOutputs:(NSArray<NSDictionary<NSString*,id>*>*)outputs {
-    
-    auto *indexedOutputInterfaces = [NSMutableArray<TIOLayerInterface*> array];
-    auto *namedOutputInterfaces = [NSMutableDictionary<NSString*,TIOLayerInterface*> dictionary];
-    auto *namedOutputToIndex = [NSMutableDictionary<NSString*,NSNumber*> dictionary];
-    
-    auto isQuantized = self.quantized;
-    auto isInput = NO;
-    
-    __block BOOL error = NO;
-    
-    [outputs enumerateObjectsUsingBlock:^(NSDictionary<NSString *,id> * _Nonnull output, NSUInteger idx, BOOL * _Nonnull stop) {
-    
-        NSString *type = output[@"type"];
-        NSString *name = output[@"name"];
-        
-        TIOLayerInterface *interface;
-        
-        if ( [type isEqualToString:kTensorTypeVector] ) {
-            interface = TIOTFLiteModelParseTIOVectorDescription(output, isInput, isQuantized, self->_bundle);
-        } else if ( [type isEqualToString:kTensorTypeImage] ) {
-            interface = TIOTFLiteModelParseTIOPixelBufferDescription(output, isInput, isQuantized);
-        }
-        
-        if ( interface == nil ) {
-            error = YES;
-            *stop = YES;
-            return;
-        }
-        
-        [indexedOutputInterfaces addObject:interface];
-        namedOutputInterfaces[name] = interface;
-        namedOutputToIndex[name] = @(idx);
-    }];
-    
-    _indexedOutputInterfaces = indexedOutputInterfaces.copy;
-    _namedOutputInterfaces = namedOutputInterfaces.copy;
-    _namedOutputToIndex = namedOutputToIndex.copy;
-    
-    return !error;
+    return error ? nil : interfaces.copy;
 }
 
 /**
  * Parses the train dict if this model includes "train" as one of its supported modes.
  *
  * @param train A JSON dictionary describing the model's training options.
- *
  * @return BOOL `YES` if the JSON dictionary was successfully parsed, `NO` otherwise.
  */
 
@@ -340,28 +253,28 @@ typedef std::vector<std::string> TensorNames;
 
 // MARK: - Input and Output Features
 
-- (NSArray<TIOLayerInterface*>*)inputs {
-    return _indexedInputInterfaces;
+- (NSArray<TIOLayerInterface*>*)inputs {;
+    return self.io.inputs.all;
 }
 
 - (NSArray<TIOLayerInterface*>*)outputs {
-    return _indexedOutputInterfaces;
+    return self.io.outputs.all;
 }
 
 - (id<TIOLayerDescription>)descriptionOfInputAtIndex:(NSUInteger)index {
-    return _indexedInputInterfaces[index].dataDescription;
+    return self.io.inputs[index].dataDescription;
 }
 
 - (id<TIOLayerDescription>)descriptionOfInputWithName:(NSString*)name {
-    return _namedInputInterfaces[name].dataDescription;
+    return self.io.inputs[name].dataDescription;
 }
 
 - (id<TIOLayerDescription>)descriptionOfOutputAtIndex:(NSUInteger)index {
-    return _indexedOutputInterfaces[index].dataDescription;
+    return self.io.outputs[index].dataDescription;
 }
 
 - (id<TIOLayerDescription>)descriptionOfOutputWithName:(NSString*)name {
-    return _namedOutputInterfaces[name].dataDescription;
+    return self.io.outputs[name].dataDescription;
 }
 
 // MARK: - Perform Inference
@@ -410,7 +323,7 @@ typedef std::vector<std::string> TensorNames;
 - (id<TIOData>)run:(TIOBatch *)batch error:(NSError * _Nullable *)error {
     // TODO: refactor run:error: and train:error: preparation. methods are identical (#157)
     
-    NSAssert([[NSSet setWithArray:batch.keys] isEqualToSet:[NSSet setWithArray:_namedInputInterfaces.allKeys]], @"Batch keys do not match input layer names");
+    NSAssert([[NSSet setWithArray:batch.keys] isEqualToSet:[NSSet setWithArray:self.io.inputs.keys]], @"Batch keys do not match input layer names");
     NSAssert(batch.count == 1, @"Run batch size must currently be 1 for TensorFlow models");
     
     NSError *loadError;
@@ -461,7 +374,7 @@ typedef std::vector<std::string> TensorNames;
     NamedTensors inputs;
     
     for ( NSString *key in batch.keys ) {
-        TIOLayerInterface *interface = _namedInputInterfaces[key];
+        TIOLayerInterface *interface = self.io.inputs[key];
         NamedTensor input = [self _prepareBatchInput:batch interface:interface];
         inputs.push_back(input);
     }
@@ -527,19 +440,19 @@ typedef std::vector<std::string> TensorNames;
         NSDictionary<NSString*,id<TIOData>> *dictionaryData = (NSDictionary*)data;
         
         for ( NSString *name in dictionaryData ) {
-            assert([_namedInputInterfaces.allKeys containsObject:name]);
+            assert([self.io.inputs.keys containsObject:name]);
         
-            TIOLayerInterface *interface = _namedInputInterfaces[name];
+            TIOLayerInterface *interface = self.io.inputs[name];
             id<TIOData> inputData = dictionaryData[name];
         
             NamedTensor input = [self _prepareInput:inputData interface:interface];
             inputs.push_back(input);
         }
-    } else if ( _indexedInputInterfaces.count == 1 ) {
+    } else if ( self.io.inputs.count == 1 ) {
     
         // If there is a single input available, simply take the input as it is
         
-        TIOLayerInterface *interface = _indexedInputInterfaces[0];
+        TIOLayerInterface *interface = self.io.inputs[0];
         id<TIOData> inputData = data;
         
         NamedTensor input = [self _prepareInput:inputData interface:interface];
@@ -553,10 +466,10 @@ typedef std::vector<std::string> TensorNames;
         // With an array input, iterate through its entries, preparing the indexed tensors with their values
         
         NSArray<id<TIOData>> *arrayData = (NSArray*)data;
-        assert(arrayData.count == _indexedInputInterfaces.count);
+        assert(arrayData.count == self.io.inputs.count);
         
         for ( NSUInteger index = 0; index < arrayData.count; index++ ) {
-            TIOLayerInterface *interface = _indexedInputInterfaces[index];
+            TIOLayerInterface *interface = self.io.inputs[index];
             id<TIOData> inputData = arrayData[index];
             NamedTensor input = [self _prepareInput:inputData interface:interface];
             inputs.push_back(input);
@@ -612,7 +525,7 @@ typedef std::vector<std::string> TensorNames;
     TensorNames output_names;
     Tensors outputs;
     
-    for (TIOLayerInterface *interface in _indexedOutputInterfaces) {
+    for (TIOLayerInterface *interface in self.io.outputs.all) {
         output_names.push_back(interface.name.UTF8String);
     }
     
@@ -645,8 +558,8 @@ typedef std::vector<std::string> TensorNames;
    
     NSMutableDictionary<NSString*,id<TIOData>> *outputs = [[NSMutableDictionary alloc] init];
 
-    for ( int index = 0; index < _indexedOutputInterfaces.count; index++ ) {
-        TIOLayerInterface *interface = _indexedOutputInterfaces[index];
+    for ( int index = 0; index < self.io.outputs.count; index++ ) {
+        TIOLayerInterface *interface = self.io.outputs[index];
         tensorflow::Tensor tensor = outputTensors[index];
         
         id<TIOData> data = [self _captureOutput:tensor interface:interface];
@@ -740,7 +653,7 @@ typedef std::vector<std::string> TensorNames;
     NamedTensors inputs;
     
     for ( NSString *key in batch.keys ) {
-        TIOLayerInterface *interface = _namedInputInterfaces[key];
+        TIOLayerInterface *interface = self.io.inputs[key];
         NamedTensor input = [self _prepareTrainingInput:batch interface:interface];
         inputs.push_back(input);
     }
@@ -798,7 +711,7 @@ typedef std::vector<std::string> TensorNames;
     
     // Output names
     
-    for (TIOLayerInterface *interface in _indexedOutputInterfaces) {
+    for (TIOLayerInterface *interface in self.io.outputs.all) {
         output_names.push_back(interface.name.UTF8String);
     }
     
@@ -855,8 +768,8 @@ typedef std::vector<std::string> TensorNames;
    
     NSMutableDictionary<NSString*,id<TIOData>> *outputs = [[NSMutableDictionary alloc] init];
 
-    for ( int index = 0; index < _indexedOutputInterfaces.count; index++ ) {
-        TIOLayerInterface *interface = _indexedOutputInterfaces[index];
+    for ( int index = 0; index < self.io.outputs.count; index++ ) {
+        TIOLayerInterface *interface = self.io.outputs[index];
         tensorflow::Tensor tensor = outputTensors[index];
         
         id<TIOData> data = [self _captureTrainingOutput:tensor interface:interface];


### PR DESCRIPTION
Addresses https://github.com/doc-ai/tensorio-ios/issues/136

@RohanJahagirdar The Java implementation is already doing parsing at the bundle level but it does not encapsulate the descriptions on a separate `io` object