### PR TITLE
use header imports instead of module imports for dependent frameworks

### DIFF
--- a/TensorIO/Classes/Core/TIOModel/TIOModelBundleValidator.m
+++ b/TensorIO/Classes/Core/TIOModel/TIOModelBundleValidator.m
@@ -22,7 +22,9 @@
 #import "TIOModelBundle.h"
 #import "TIOModelBackend.h"
 
-@import DSJSONSchemaValidation;
+#import "DSJSONSchemaValidator.h"
+#import "DSJSONSchema.h"
+#import "DSJSONSchemaSpecification.h"
 
 static NSError * TIOMalformedJSONError(void);
 static NSError * TIOInvalidFilepathError(NSString * path);


### PR DESCRIPTION
fix is necessary for the doc.ai app, where `use_frameworks!` is not enabled in the podfile.