### PR TITLE
lock 1.0 builds to TensorIOTensorFlow 1.13.x, etc

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
   - DSJSONSchemaValidation (2.0.7)
   - TensorFlowLite (1.13.1)
-  - TensorIO (1.0):
+  - TensorIO (1.0.1):
     - DSJSONSchemaValidation
-    - TensorIO/Core (= 1.0)
-  - TensorIO/Core (1.0):
+    - TensorIO/Core (= 1.0.1)
+  - TensorIO/Core (1.0.1):
     - DSJSONSchemaValidation
-  - TensorIO/TFLite (1.0):
+  - TensorIO/TFLite (1.0.1):
     - DSJSONSchemaValidation
     - TensorFlowLite
     - TensorIO/Core
@@ -27,7 +27,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   DSJSONSchemaValidation: 46e30ccfa9908c49d184f453d556f55aa0aac1ff
   TensorFlowLite: 8b9dc4eb32eac0f8cb660c66bca7604da56dcc5a
-  TensorIO: a8676eb2f819d136bbbdc458a8a010b92342ac0d
+  TensorIO: 1cd798d391b0c6ee85bf9d1d2e153308722dd976
 
 PODFILE CHECKSUM: 3ec20863fd64cde2866456ffa1a33adad3b2b12c
 

--- a/Example/Pods/Local Podspecs/TensorIO.podspec.json
+++ b/Example/Pods/Local Podspecs/TensorIO.podspec.json
@@ -1,8 +1,8 @@
 {
   "name": "TensorIO",
-  "version": "1.0",
-  "summary": "An Objective-C and Swift wrapper for TensorFlow Lite and TensorFlow, with support for Federated Learning.",
-  "description": "Perform inference with TensorFlow Lite or full TensorFlow models using all the conveniences of Objective-C or Swift",
+  "version": "1.0.1",
+  "summary": "An Objective-C and Swift wrapper for TensorFlow Lite and TensorFlow, with support for on device training.",
+  "description": "On device inference with TensorFlow Lite or inference and training with full TensorFlow models using all the conveniences of Objective-C or Swift",
   "homepage": "https://github.com/doc-ai/tensorio-ios",
   "license": {
     "type": "Apache 2",
@@ -13,7 +13,7 @@
   },
   "source": {
     "git": "https://github.com/doc-ai/tensorio-ios.git",
-    "tag": "1.0"
+    "tag": "1.0.1"
   },
   "platforms": {
     "ios": "12.0"
@@ -45,7 +45,7 @@
       "name": "Core",
       "source_files": "TensorIO/Classes/Core/**/*",
       "pod_target_xcconfig": {
-        "GCC_PREPROCESSOR_DEFINITIONS": "TIO_CORE=1 TIO_VERSION=1.0"
+        "GCC_PREPROCESSOR_DEFINITIONS": "TIO_CORE=1 TIO_VERSION=1.0.1"
       }
     },
     {
@@ -79,7 +79,7 @@
 
         ],
         "TensorIOTensorFlow": [
-
+          "~> 1.13.0"
         ]
       },
       "source_files": "TensorIO/Classes/TensorFlow/**/*",

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,12 +1,12 @@
 PODS:
   - DSJSONSchemaValidation (2.0.7)
   - TensorFlowLite (1.13.1)
-  - TensorIO (1.0):
+  - TensorIO (1.0.1):
     - DSJSONSchemaValidation
-    - TensorIO/Core (= 1.0)
-  - TensorIO/Core (1.0):
+    - TensorIO/Core (= 1.0.1)
+  - TensorIO/Core (1.0.1):
     - DSJSONSchemaValidation
-  - TensorIO/TFLite (1.0):
+  - TensorIO/TFLite (1.0.1):
     - DSJSONSchemaValidation
     - TensorFlowLite
     - TensorIO/Core
@@ -27,7 +27,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   DSJSONSchemaValidation: 46e30ccfa9908c49d184f453d556f55aa0aac1ff
   TensorFlowLite: 8b9dc4eb32eac0f8cb660c66bca7604da56dcc5a
-  TensorIO: a8676eb2f819d136bbbdc458a8a010b92342ac0d
+  TensorIO: 1cd798d391b0c6ee85bf9d1d2e153308722dd976
 
 PODFILE CHECKSUM: 3ec20863fd64cde2866456ffa1a33adad3b2b12c
 

--- a/Example/Pods/Target Support Files/TensorIO/TensorIO-Info.plist
+++ b/Example/Pods/Target Support Files/TensorIO/TensorIO-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>1.0.0</string>
+  <string>1.0.1</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/TensorIO.xcodeproj/project.pbxproj
+++ b/Example/TensorIO.xcodeproj/project.pbxproj
@@ -656,7 +656,7 @@
 				GCC_PREFIX_HEADER = "TensorIO/TensorIO-Prefix.pch";
 				INFOPLIST_FILE = "TensorIO/TensorIO-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.9.7;
+				MARKETING_VERSION = 1.0.1;
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -675,7 +675,7 @@
 				GCC_PREFIX_HEADER = "TensorIO/TensorIO-Prefix.pch";
 				INFOPLIST_FILE = "TensorIO/TensorIO-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.9.7;
+				MARKETING_VERSION = 1.0.1;
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/SwiftExample/Podfile.lock
+++ b/SwiftExample/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
   - DSJSONSchemaValidation (2.0.7)
   - TensorFlowLite (1.13.1)
-  - TensorIO (1.0):
+  - TensorIO (1.0.1):
     - DSJSONSchemaValidation
-    - TensorIO/Core (= 1.0)
-  - TensorIO/Core (1.0):
+    - TensorIO/Core (= 1.0.1)
+  - TensorIO/Core (1.0.1):
     - DSJSONSchemaValidation
-  - TensorIO/TFLite (1.0):
+  - TensorIO/TFLite (1.0.1):
     - DSJSONSchemaValidation
     - TensorFlowLite
     - TensorIO/Core
@@ -27,7 +27,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   DSJSONSchemaValidation: 46e30ccfa9908c49d184f453d556f55aa0aac1ff
   TensorFlowLite: 8b9dc4eb32eac0f8cb660c66bca7604da56dcc5a
-  TensorIO: a8676eb2f819d136bbbdc458a8a010b92342ac0d
+  TensorIO: 1cd798d391b0c6ee85bf9d1d2e153308722dd976
 
 PODFILE CHECKSUM: 2e76eddda1d036cc6dc70ac8020f70ff2f67e8af
 

--- a/SwiftExample/Pods/Local Podspecs/TensorIO.podspec.json
+++ b/SwiftExample/Pods/Local Podspecs/TensorIO.podspec.json
@@ -1,8 +1,8 @@
 {
   "name": "TensorIO",
-  "version": "1.0",
-  "summary": "An Objective-C and Swift wrapper for TensorFlow Lite and TensorFlow, with support for Federated Learning.",
-  "description": "Perform inference with TensorFlow Lite or full TensorFlow models using all the conveniences of Objective-C or Swift",
+  "version": "1.0.1",
+  "summary": "An Objective-C and Swift wrapper for TensorFlow Lite and TensorFlow, with support for on device training.",
+  "description": "On device inference with TensorFlow Lite or inference and training with full TensorFlow models using all the conveniences of Objective-C or Swift",
   "homepage": "https://github.com/doc-ai/tensorio-ios",
   "license": {
     "type": "Apache 2",
@@ -13,7 +13,7 @@
   },
   "source": {
     "git": "https://github.com/doc-ai/tensorio-ios.git",
-    "tag": "1.0"
+    "tag": "1.0.1"
   },
   "platforms": {
     "ios": "12.0"
@@ -45,7 +45,7 @@
       "name": "Core",
       "source_files": "TensorIO/Classes/Core/**/*",
       "pod_target_xcconfig": {
-        "GCC_PREPROCESSOR_DEFINITIONS": "TIO_CORE=1 TIO_VERSION=1.0"
+        "GCC_PREPROCESSOR_DEFINITIONS": "TIO_CORE=1 TIO_VERSION=1.0.1"
       }
     },
     {
@@ -79,7 +79,7 @@
 
         ],
         "TensorIOTensorFlow": [
-
+          "~> 1.13.0"
         ]
       },
       "source_files": "TensorIO/Classes/TensorFlow/**/*",

--- a/SwiftExample/Pods/Manifest.lock
+++ b/SwiftExample/Pods/Manifest.lock
@@ -1,12 +1,12 @@
 PODS:
   - DSJSONSchemaValidation (2.0.7)
   - TensorFlowLite (1.13.1)
-  - TensorIO (1.0):
+  - TensorIO (1.0.1):
     - DSJSONSchemaValidation
-    - TensorIO/Core (= 1.0)
-  - TensorIO/Core (1.0):
+    - TensorIO/Core (= 1.0.1)
+  - TensorIO/Core (1.0.1):
     - DSJSONSchemaValidation
-  - TensorIO/TFLite (1.0):
+  - TensorIO/TFLite (1.0.1):
     - DSJSONSchemaValidation
     - TensorFlowLite
     - TensorIO/Core
@@ -27,7 +27,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   DSJSONSchemaValidation: 46e30ccfa9908c49d184f453d556f55aa0aac1ff
   TensorFlowLite: 8b9dc4eb32eac0f8cb660c66bca7604da56dcc5a
-  TensorIO: a8676eb2f819d136bbbdc458a8a010b92342ac0d
+  TensorIO: 1cd798d391b0c6ee85bf9d1d2e153308722dd976
 
 PODFILE CHECKSUM: 2e76eddda1d036cc6dc70ac8020f70ff2f67e8af
 

--- a/SwiftExample/Pods/Target Support Files/TensorIO/TensorIO-Info.plist
+++ b/SwiftExample/Pods/Target Support Files/TensorIO/TensorIO-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>1.0.0</string>
+  <string>1.0.1</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/SwiftExample/SwiftExample.xcodeproj/project.pbxproj
+++ b/SwiftExample/SwiftExample.xcodeproj/project.pbxproj
@@ -515,7 +515,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.9.7;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.doc.SwiftExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "SwiftExample/SwiftExample-Bridging-Header.h";
@@ -539,7 +539,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.9.7;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.doc.SwiftExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "SwiftExample/SwiftExample-Bridging-Header.h";

--- a/SwiftTensorFlowExample/Podfile.lock
+++ b/SwiftTensorFlowExample/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
   - DSJSONSchemaValidation (2.0.7)
-  - TensorIO (1.0):
+  - TensorIO (1.0.1):
     - DSJSONSchemaValidation
-    - TensorIO/Core (= 1.0)
-  - TensorIO/Core (1.0):
+    - TensorIO/Core (= 1.0.1)
+  - TensorIO/Core (1.0.1):
     - DSJSONSchemaValidation
-  - TensorIO/TensorFlow (1.0):
+  - TensorIO/TensorFlow (1.0.1):
     - DSJSONSchemaValidation
     - TensorIO/Core
-    - TensorIOTensorFlow
-  - TensorIOTensorFlow (1.13.5)
+    - TensorIOTensorFlow (~> 1.13.0)
+  - TensorIOTensorFlow (1.13.6)
 
 DEPENDENCIES:
   - TensorIO (from `../`)
@@ -26,8 +26,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   DSJSONSchemaValidation: 46e30ccfa9908c49d184f453d556f55aa0aac1ff
-  TensorIO: a8676eb2f819d136bbbdc458a8a010b92342ac0d
-  TensorIOTensorFlow: 66391fb72910e7814aec5c0ab1d4789a81ac3399
+  TensorIO: 1cd798d391b0c6ee85bf9d1d2e153308722dd976
+  TensorIOTensorFlow: 9da41ecb33073d226c592fe945a63437b973685a
 
 PODFILE CHECKSUM: 122273e44cda5617be20b61aa18cf3a20991bfab
 

--- a/SwiftTensorFlowExample/SwiftTensorFlowExample.xcodeproj/project.pbxproj
+++ b/SwiftTensorFlowExample/SwiftTensorFlowExample.xcodeproj/project.pbxproj
@@ -558,7 +558,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.9.7;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.doc.SwiftTensorFlowExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "SwiftTensorFlowExample/SwiftTensorFlowExample-Bridging-Header.h";
@@ -582,7 +582,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.9.7;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.doc.SwiftTensorFlowExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "SwiftTensorFlowExample/SwiftTensorFlowExample-Bridging-Header.h";

--- a/TensorFlowExample/Podfile.lock
+++ b/TensorFlowExample/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
   - DSJSONSchemaValidation (2.0.7)
-  - TensorIO (1.0):
+  - TensorIO (1.0.1):
     - DSJSONSchemaValidation
-    - TensorIO/Core (= 1.0)
-  - TensorIO/Core (1.0):
+    - TensorIO/Core (= 1.0.1)
+  - TensorIO/Core (1.0.1):
     - DSJSONSchemaValidation
-  - TensorIO/TensorFlow (1.0):
+  - TensorIO/TensorFlow (1.0.1):
     - DSJSONSchemaValidation
     - TensorIO/Core
-    - TensorIOTensorFlow
-  - TensorIOTensorFlow (1.13.5)
+    - TensorIOTensorFlow (~> 1.13.0)
+  - TensorIOTensorFlow (1.13.6)
 
 DEPENDENCIES:
   - TensorIO (from `../`)
@@ -26,8 +26,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   DSJSONSchemaValidation: 46e30ccfa9908c49d184f453d556f55aa0aac1ff
-  TensorIO: a8676eb2f819d136bbbdc458a8a010b92342ac0d
-  TensorIOTensorFlow: 66391fb72910e7814aec5c0ab1d4789a81ac3399
+  TensorIO: 1cd798d391b0c6ee85bf9d1d2e153308722dd976
+  TensorIOTensorFlow: 9da41ecb33073d226c592fe945a63437b973685a
 
 PODFILE CHECKSUM: f3621b2a05e457cf5ae380adfb2c157901c0ecd4
 

--- a/TensorFlowExample/TensorFlowExample.xcodeproj/project.pbxproj
+++ b/TensorFlowExample/TensorFlowExample.xcodeproj/project.pbxproj
@@ -588,7 +588,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.9.7;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.doc.TensorFlowExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -608,7 +608,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.9.7;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.doc.TensorFlowExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/TensorIO.podspec
+++ b/TensorIO.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'TensorIO'
-  s.version          = '1.0'
+  s.version          = '1.0.1'
   s.summary          = 'An Objective-C and Swift wrapper for TensorFlow Lite and TensorFlow, with support for on device training.'
   s.description      = 'On device inference with TensorFlow Lite or inference and training with full TensorFlow models using all the conveniences of Objective-C or Swift'
   s.homepage         = 'https://github.com/doc-ai/tensorio-ios'
@@ -65,7 +65,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'TensorFlow' do |ss|
     ss.dependency 'TensorIO/Core'
-    ss.dependency 'TensorIOTensorFlow'
+    ss.dependency 'TensorIOTensorFlow', '~> 1.13.0'
 
     ss.source_files = 'TensorIO/Classes/TensorFlow/**/*'
     ss.private_header_files = [


### PR DESCRIPTION
Will tag this 1.0.1 and release pod.

- lock 1.0 builds to TensorIOTensorFlow 1.13.x, 
- update version to 1.0.1
- pod install, 
- run all test