### PR TITLE
R1.2 xcconfig

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
   - DSJSONSchemaValidation (2.0.7)
   - TensorFlowLite (1.13.1)
-  - TensorIO (1.2.2):
+  - TensorIO (1.2.3):
     - DSJSONSchemaValidation
-    - TensorIO/Core (= 1.2.2)
-  - TensorIO/Core (1.2.2):
+    - TensorIO/Core (= 1.2.3)
+  - TensorIO/Core (1.2.3):
     - DSJSONSchemaValidation
-  - TensorIO/TFLite (1.2.2):
+  - TensorIO/TFLite (1.2.3):
     - DSJSONSchemaValidation
     - TensorFlowLite
     - TensorIO/Core
@@ -27,7 +27,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   DSJSONSchemaValidation: 46e30ccfa9908c49d184f453d556f55aa0aac1ff
   TensorFlowLite: 8b9dc4eb32eac0f8cb660c66bca7604da56dcc5a
-  TensorIO: 0cbd93124efe9193fca0ef721f8c83395e430102
+  TensorIO: cb64c2b34b356d074f5bc403192511a4e2cc9e12
 
 PODFILE CHECKSUM: 3ec20863fd64cde2866456ffa1a33adad3b2b12c
 

--- a/Example/Pods/Local Podspecs/TensorIO.podspec.json
+++ b/Example/Pods/Local Podspecs/TensorIO.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "TensorIO",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "summary": "An Objective-C and Swift wrapper for TensorFlow Lite and TensorFlow, with support for on device training.",
   "description": "On device inference with TensorFlow Lite or inference and training with full TensorFlow models using all the conveniences of Objective-C or Swift",
   "homepage": "https://github.com/doc-ai/tensorio-ios",
@@ -13,7 +13,7 @@
   },
   "source": {
     "git": "https://github.com/doc-ai/tensorio-ios.git",
-    "tag": "1.2.2"
+    "tag": "1.2.3"
   },
   "platforms": {
     "ios": "12.0"
@@ -45,7 +45,7 @@
       "name": "Core",
       "source_files": "TensorIO/Classes/Core/**/*",
       "pod_target_xcconfig": {
-        "GCC_PREPROCESSOR_DEFINITIONS": "TIO_CORE=1 TIO_VERSION=1.2.2"
+        "GCC_PREPROCESSOR_DEFINITIONS": "TIO_CORE=1 TIO_VERSION=1.2.3"
       }
     },
     {
@@ -79,7 +79,7 @@
 
         ],
         "TensorIOTensorFlow": [
-          "~> 2.0.2"
+          "~> 2.0.3"
         ]
       },
       "source_files": "TensorIO/Classes/TensorFlow/**/*",
@@ -92,7 +92,7 @@
       },
       "xcconfig": {
         "HEADER_SEARCH_PATHS": "\"${PODS_ROOT}/TensorIOTensorFlow/Frameworks/tensorflow.framework/Headers\"",
-        "OTHER_LDFLAGS": "-force_load \"${PODS_ROOT}/TensorIOTensorFlow/Frameworks/tensorflow.framework/tensorflow\" \"-L ${PODS_ROOT}/TensorIOTensorFlow/Frameworks/tensorflow.framework\""
+        "OTHER_LDFLAGS": "-force_load \"${PODS_ROOT}/TensorIOTensorFlow/Frameworks/tensorflow.framework/tensorflow\""
       },
       "pod_target_xcconfig": {
         "GCC_PREPROCESSOR_DEFINITIONS": "TIO_TENSORFLOW=1"

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,12 +1,12 @@
 PODS:
   - DSJSONSchemaValidation (2.0.7)
   - TensorFlowLite (1.13.1)
-  - TensorIO (1.2.2):
+  - TensorIO (1.2.3):
     - DSJSONSchemaValidation
-    - TensorIO/Core (= 1.2.2)
-  - TensorIO/Core (1.2.2):
+    - TensorIO/Core (= 1.2.3)
+  - TensorIO/Core (1.2.3):
     - DSJSONSchemaValidation
-  - TensorIO/TFLite (1.2.2):
+  - TensorIO/TFLite (1.2.3):
     - DSJSONSchemaValidation
     - TensorFlowLite
     - TensorIO/Core
@@ -27,7 +27,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   DSJSONSchemaValidation: 46e30ccfa9908c49d184f453d556f55aa0aac1ff
   TensorFlowLite: 8b9dc4eb32eac0f8cb660c66bca7604da56dcc5a
-  TensorIO: 0cbd93124efe9193fca0ef721f8c83395e430102
+  TensorIO: cb64c2b34b356d074f5bc403192511a4e2cc9e12
 
 PODFILE CHECKSUM: 3ec20863fd64cde2866456ffa1a33adad3b2b12c
 

--- a/Example/Pods/Target Support Files/TensorIO/TensorIO-Info.plist
+++ b/Example/Pods/Target Support Files/TensorIO/TensorIO-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>1.2.2</string>
+  <string>1.2.3</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/TensorIO.xcodeproj/project.pbxproj
+++ b/Example/TensorIO.xcodeproj/project.pbxproj
@@ -656,7 +656,7 @@
 				GCC_PREFIX_HEADER = "TensorIO/TensorIO-Prefix.pch";
 				INFOPLIST_FILE = "TensorIO/TensorIO-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 1.2.2;
+				MARKETING_VERSION = 1.2.3;
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -675,7 +675,7 @@
 				GCC_PREFIX_HEADER = "TensorIO/TensorIO-Prefix.pch";
 				INFOPLIST_FILE = "TensorIO/TensorIO-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 1.2.2;
+				MARKETING_VERSION = 1.2.3;
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/SwiftExample/Podfile.lock
+++ b/SwiftExample/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
   - DSJSONSchemaValidation (2.0.7)
   - TensorFlowLite (1.13.1)
-  - TensorIO (1.2.2):
+  - TensorIO (1.2.3):
     - DSJSONSchemaValidation
-    - TensorIO/Core (= 1.2.2)
-  - TensorIO/Core (1.2.2):
+    - TensorIO/Core (= 1.2.3)
+  - TensorIO/Core (1.2.3):
     - DSJSONSchemaValidation
-  - TensorIO/TFLite (1.2.2):
+  - TensorIO/TFLite (1.2.3):
     - DSJSONSchemaValidation
     - TensorFlowLite
     - TensorIO/Core
@@ -27,7 +27,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   DSJSONSchemaValidation: 46e30ccfa9908c49d184f453d556f55aa0aac1ff
   TensorFlowLite: 8b9dc4eb32eac0f8cb660c66bca7604da56dcc5a
-  TensorIO: 0cbd93124efe9193fca0ef721f8c83395e430102
+  TensorIO: cb64c2b34b356d074f5bc403192511a4e2cc9e12
 
 PODFILE CHECKSUM: 2e76eddda1d036cc6dc70ac8020f70ff2f67e8af
 

--- a/SwiftExample/Pods/Local Podspecs/TensorIO.podspec.json
+++ b/SwiftExample/Pods/Local Podspecs/TensorIO.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "TensorIO",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "summary": "An Objective-C and Swift wrapper for TensorFlow Lite and TensorFlow, with support for on device training.",
   "description": "On device inference with TensorFlow Lite or inference and training with full TensorFlow models using all the conveniences of Objective-C or Swift",
   "homepage": "https://github.com/doc-ai/tensorio-ios",
@@ -13,7 +13,7 @@
   },
   "source": {
     "git": "https://github.com/doc-ai/tensorio-ios.git",
-    "tag": "1.2.2"
+    "tag": "1.2.3"
   },
   "platforms": {
     "ios": "12.0"
@@ -45,7 +45,7 @@
       "name": "Core",
       "source_files": "TensorIO/Classes/Core/**/*",
       "pod_target_xcconfig": {
-        "GCC_PREPROCESSOR_DEFINITIONS": "TIO_CORE=1 TIO_VERSION=1.2.2"
+        "GCC_PREPROCESSOR_DEFINITIONS": "TIO_CORE=1 TIO_VERSION=1.2.3"
       }
     },
     {
@@ -79,7 +79,7 @@
 
         ],
         "TensorIOTensorFlow": [
-          "~> 2.0.2"
+          "~> 2.0.3"
         ]
       },
       "source_files": "TensorIO/Classes/TensorFlow/**/*",
@@ -92,7 +92,7 @@
       },
       "xcconfig": {
         "HEADER_SEARCH_PATHS": "\"${PODS_ROOT}/TensorIOTensorFlow/Frameworks/tensorflow.framework/Headers\"",
-        "OTHER_LDFLAGS": "-force_load \"${PODS_ROOT}/TensorIOTensorFlow/Frameworks/tensorflow.framework/tensorflow\" \"-L ${PODS_ROOT}/TensorIOTensorFlow/Frameworks/tensorflow.framework\""
+        "OTHER_LDFLAGS": "-force_load \"${PODS_ROOT}/TensorIOTensorFlow/Frameworks/tensorflow.framework/tensorflow\""
       },
       "pod_target_xcconfig": {
         "GCC_PREPROCESSOR_DEFINITIONS": "TIO_TENSORFLOW=1"

--- a/SwiftExample/Pods/Manifest.lock
+++ b/SwiftExample/Pods/Manifest.lock
@@ -1,12 +1,12 @@
 PODS:
   - DSJSONSchemaValidation (2.0.7)
   - TensorFlowLite (1.13.1)
-  - TensorIO (1.2.2):
+  - TensorIO (1.2.3):
     - DSJSONSchemaValidation
-    - TensorIO/Core (= 1.2.2)
-  - TensorIO/Core (1.2.2):
+    - TensorIO/Core (= 1.2.3)
+  - TensorIO/Core (1.2.3):
     - DSJSONSchemaValidation
-  - TensorIO/TFLite (1.2.2):
+  - TensorIO/TFLite (1.2.3):
     - DSJSONSchemaValidation
     - TensorFlowLite
     - TensorIO/Core
@@ -27,7 +27,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   DSJSONSchemaValidation: 46e30ccfa9908c49d184f453d556f55aa0aac1ff
   TensorFlowLite: 8b9dc4eb32eac0f8cb660c66bca7604da56dcc5a
-  TensorIO: 0cbd93124efe9193fca0ef721f8c83395e430102
+  TensorIO: cb64c2b34b356d074f5bc403192511a4e2cc9e12
 
 PODFILE CHECKSUM: 2e76eddda1d036cc6dc70ac8020f70ff2f67e8af
 

--- a/SwiftExample/Pods/Target Support Files/TensorIO/TensorIO-Info.plist
+++ b/SwiftExample/Pods/Target Support Files/TensorIO/TensorIO-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>1.2.2</string>
+  <string>1.2.3</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/SwiftExample/SwiftExample.xcodeproj/project.pbxproj
+++ b/SwiftExample/SwiftExample.xcodeproj/project.pbxproj
@@ -515,7 +515,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.2;
+				MARKETING_VERSION = 1.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.doc.SwiftExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "SwiftExample/SwiftExample-Bridging-Header.h";
@@ -539,7 +539,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.2;
+				MARKETING_VERSION = 1.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.doc.SwiftExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "SwiftExample/SwiftExample-Bridging-Header.h";

--- a/SwiftTensorFlowExample/Podfile.lock
+++ b/SwiftTensorFlowExample/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
   - DSJSONSchemaValidation (2.0.7)
-  - TensorIO (1.2.2):
+  - TensorIO (1.2.3):
     - DSJSONSchemaValidation
-    - TensorIO/Core (= 1.2.2)
-  - TensorIO/Core (1.2.2):
+    - TensorIO/Core (= 1.2.3)
+  - TensorIO/Core (1.2.3):
     - DSJSONSchemaValidation
-  - TensorIO/TensorFlow (1.2.2):
+  - TensorIO/TensorFlow (1.2.3):
     - DSJSONSchemaValidation
     - TensorIO/Core
-    - TensorIOTensorFlow (~> 2.0.2)
-  - TensorIOTensorFlow (2.0.2)
+    - TensorIOTensorFlow (~> 2.0.3)
+  - TensorIOTensorFlow (2.0.3)
 
 DEPENDENCIES:
   - TensorIO (from `../`)
@@ -26,8 +26,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   DSJSONSchemaValidation: 46e30ccfa9908c49d184f453d556f55aa0aac1ff
-  TensorIO: 0cbd93124efe9193fca0ef721f8c83395e430102
-  TensorIOTensorFlow: 0cc5fdcf2c40df5260e977ee3b11d98310d19e22
+  TensorIO: cb64c2b34b356d074f5bc403192511a4e2cc9e12
+  TensorIOTensorFlow: 1aef5283bf8c39f178915a1dd7bbd8bee88c2ef4
 
 PODFILE CHECKSUM: f05081e1b68db69c02ee054df132b22bfc90c72d
 

--- a/SwiftTensorFlowExample/SwiftTensorFlowExample.xcodeproj/project.pbxproj
+++ b/SwiftTensorFlowExample/SwiftTensorFlowExample.xcodeproj/project.pbxproj
@@ -558,7 +558,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.2;
+				MARKETING_VERSION = 1.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.doc.SwiftTensorFlowExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "SwiftTensorFlowExample/SwiftTensorFlowExample-Bridging-Header.h";
@@ -582,7 +582,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.2;
+				MARKETING_VERSION = 1.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.doc.SwiftTensorFlowExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "SwiftTensorFlowExample/SwiftTensorFlowExample-Bridging-Header.h";

--- a/TensorFlowExample/Podfile
+++ b/TensorFlowExample/Podfile
@@ -2,7 +2,7 @@ platform :ios, '12.0'
 use_frameworks!
 
 target 'TensorFlowExample' do
-  
+
   pod 'TensorIO', :path => '../'
   pod 'TensorIO/TensorFlow', :path => '../'
 

--- a/TensorFlowExample/Podfile.lock
+++ b/TensorFlowExample/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
   - DSJSONSchemaValidation (2.0.7)
-  - TensorIO (1.2.2):
+  - TensorIO (1.2.3):
     - DSJSONSchemaValidation
-    - TensorIO/Core (= 1.2.2)
-  - TensorIO/Core (1.2.2):
+    - TensorIO/Core (= 1.2.3)
+  - TensorIO/Core (1.2.3):
     - DSJSONSchemaValidation
-  - TensorIO/TensorFlow (1.2.2):
+  - TensorIO/TensorFlow (1.2.3):
     - DSJSONSchemaValidation
     - TensorIO/Core
-    - TensorIOTensorFlow (~> 2.0.2)
-  - TensorIOTensorFlow (2.0.2)
+    - TensorIOTensorFlow (~> 2.0.3)
+  - TensorIOTensorFlow (2.0.3)
 
 DEPENDENCIES:
   - TensorIO (from `../`)
@@ -26,9 +26,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   DSJSONSchemaValidation: 46e30ccfa9908c49d184f453d556f55aa0aac1ff
-  TensorIO: 0cbd93124efe9193fca0ef721f8c83395e430102
-  TensorIOTensorFlow: 0cc5fdcf2c40df5260e977ee3b11d98310d19e22
+  TensorIO: cb64c2b34b356d074f5bc403192511a4e2cc9e12
+  TensorIOTensorFlow: 1aef5283bf8c39f178915a1dd7bbd8bee88c2ef4
 
-PODFILE CHECKSUM: 9df4aee916bad3d0ea4d700ed7ba74fe2a4bb030
+PODFILE CHECKSUM: d0f26cd3c4c332ee43a30725e8e264cd9aa22b0a
 
 COCOAPODS: 1.9.2

--- a/TensorFlowExample/TensorFlowExample.xcodeproj/project.pbxproj
+++ b/TensorFlowExample/TensorFlowExample.xcodeproj/project.pbxproj
@@ -588,7 +588,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.2;
+				MARKETING_VERSION = 1.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.doc.TensorFlowExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -608,7 +608,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.2;
+				MARKETING_VERSION = 1.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.doc.TensorFlowExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/TensorIO.podspec
+++ b/TensorIO.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'TensorIO'
-  s.version          = '1.2.2'
+  s.version          = '1.2.3'
   s.summary          = 'An Objective-C and Swift wrapper for TensorFlow Lite and TensorFlow, with support for on device training.'
   s.description      = 'On device inference with TensorFlow Lite or inference and training with full TensorFlow models using all the conveniences of Objective-C or Swift'
   s.homepage         = 'https://github.com/doc-ai/tensorio-ios'

--- a/TensorIO.podspec
+++ b/TensorIO.podspec
@@ -65,7 +65,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'TensorFlow' do |ss|
     ss.dependency 'TensorIO/Core'
-    ss.dependency 'TensorIOTensorFlow', '~> 2.0.2'
+    ss.dependency 'TensorIOTensorFlow', '~> 2.0.3'
 
     ss.source_files = 'TensorIO/Classes/TensorFlow/**/*'
     ss.private_header_files = [

--- a/TensorIO.podspec
+++ b/TensorIO.podspec
@@ -77,7 +77,7 @@ Pod::Spec.new do |s|
     }
     ss.xcconfig = {
       'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/TensorIOTensorFlow/Frameworks/tensorflow.framework/Headers"',
-      'OTHER_LDFLAGS' => '-force_load "${PODS_ROOT}/TensorIOTensorFlow/Frameworks/tensorflow.framework/tensorflow" "-L ${PODS_ROOT}/TensorIOTensorFlow/Frameworks/tensorflow.framework"'
+      'OTHER_LDFLAGS' => '-force_load "${PODS_ROOT}/TensorIOTensorFlow/Frameworks/tensorflow.framework/tensorflow"'
     }
     ss.pod_target_xcconfig = {
       'GCC_PREPROCESSOR_DEFINITIONS' => 'TIO_TENSORFLOW=1'


### PR DESCRIPTION
Following up with xcconfig fixes in the TensorFlow dependency, remove an unnecessary linker from. This is all part of trying to track down #192 although still no fix with these changes.